### PR TITLE
feat: Custom TypePath impl for component/resource

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serialize = ["dep:serde", "rand_core/serde1", "rand_chacha?/serde1"]
 
 [dependencies]
 # bevy
-bevy = { git = "https://github.com/MrGVSV/bevy/", branch = "reflect-type-path-opt-out", default-features = false }
+bevy = { version = "0.11.1", default-features = false }
 
 # others
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["game", "bevy", "rand", "rng"]
 categories = ["game-engines", "algorithms"]
 exclude = ["/.*"]
 resolver = "2"
-rust-version = "1.67.0"
+rust-version = "1.70.0"
 
 [features]
 default = ["serialize", "thread_local_entropy"]
@@ -19,7 +19,7 @@ serialize = ["dep:serde", "rand_core/serde1", "rand_chacha?/serde1"]
 
 [dependencies]
 # bevy
-bevy = { version = "0.10", default-features = false }
+bevy = { git = "https://github.com/MrGVSV/bevy/", branch = "reflect-type-path-opt-out", default-features = false }
 
 # others
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ All recommended crates implement the necessary traits to be compatible with `bev
 - **`thread_local_entropy`** - Enables `ThreadLocalEntropy`, overriding `SeedableRng::from_entropy` implementations to make use of thread local entropy sources for faster PRNG initialisation. Enabled by default.
 - **`serialize`** - Enables [`Serialize`] and [`Deserialize`] derives. Enabled by default.
 
+## Note about Reflection & `TypePath` stability.
+
+All `rand` PRNGs do not implement `TypePath` in any form, even as an optional feature, due to lack of native support for reflection in Rust. As such, while the components/resource in this library are *stable* and implement a stable `TypePath` for themselves, PRNGs rely on `std::any::type_name` for returning the type's name/path, which is NOT guaranteed to be stable for all versions of the compiler. As such, there may be instabilities/compatibilities with different compiler versions and compilations, as this instability infects the overall `TypePath` via the generic portion of the type path.
+
+If there arises problems with regards to stability for reflection purposes, please make an issue with regards to that in this repository, so I can track such occurrences. Tests are included in the crate anyway to hopefully detect such cases in the future.
+
 ## Supported Versions & MSRV
 
 `bevy_rand` uses the same MSRV as `bevy`.

--- a/README.md
+++ b/README.md
@@ -178,9 +178,10 @@ All recommended crates implement the necessary traits to be compatible with `bev
 
 `bevy_rand` uses the same MSRV as `bevy`.
 
-| `bevy_rand` | `bevy` |
-| ----------- | ------ |
-| v0.1        | v0.10  |
+| `bevy_rand` | `bevy`  |
+| ----------- | ------- |
+| v0.2        | v0.11.1 |
+| v0.1        | v0.10   |
 
 ## License
 

--- a/examples/turn_based_game.rs
+++ b/examples/turn_based_game.rs
@@ -45,9 +45,12 @@ struct Health {
 
 fn main() {
     App::new()
-        .add_plugin(EntropyPlugin::<ChaCha8Rng>::with_seed([1; 32]))
-        .add_startup_systems((setup_player, setup_enemies).chain())
-        .add_systems((determine_attack_order.pipe(attack_turn), buff_entities).chain())
+        .add_plugins(EntropyPlugin::<ChaCha8Rng>::with_seed([1; 32]))
+        .add_systems(Startup, (setup_player, setup_enemies).chain())
+        .add_systems(
+            Update,
+            (determine_attack_order.pipe(attack_turn), buff_entities).chain(),
+        )
         .run();
 }
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -2,8 +2,8 @@ use std::fmt::Debug;
 
 use crate::{resource::GlobalEntropy, traits::SeedableEntropySource};
 use bevy::{
-    prelude::{Component, FromReflect, Mut, Reflect, ReflectComponent, ResMut},
-    reflect::ReflectFromReflect,
+    prelude::{Component, Mut, Reflect, ReflectComponent, ReflectFromReflect, ResMut},
+    reflect::{utility::GenericTypePathCell, TypePath},
 };
 use rand_core::{RngCore, SeedableRng};
 
@@ -89,7 +89,8 @@ use serde::{Deserialize, Serialize};
 ///    }
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Component, Reflect, FromReflect)]
+#[derive(Debug, Clone, PartialEq, Eq, Component, Reflect)]
+#[reflect_value(type_path = false)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serialize",
@@ -119,6 +120,30 @@ impl<R: SeedableEntropySource + 'static> EntropyComponent<R> {
     #[inline]
     pub fn reseed(&mut self, seed: R::Seed) {
         self.0 = R::from_seed(seed);
+    }
+}
+
+
+impl<R: SeedableEntropySource + 'static> TypePath for EntropyComponent<R> {
+    fn type_path() -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
+    fn short_type_path() -> &'static str {
+        static CELL: GenericTypePathCell = GenericTypePathCell::new();
+        CELL.get_or_insert::<Self, _>(|| bevy::utils::get_short_name(std::any::type_name::<Self>()))
+    }
+
+    fn type_ident() -> Option<&'static str> {
+        Some("EntropyComponent")
+    }
+
+    fn crate_name() -> Option<&'static str> {
+        Some("bevy_rand")
+    }
+
+    fn module_path() -> Option<&'static str> {
+        Some("bevy_rand::component")
     }
 }
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -123,15 +123,20 @@ impl<R: SeedableEntropySource + 'static> EntropyComponent<R> {
     }
 }
 
-
 impl<R: SeedableEntropySource + 'static> TypePath for EntropyComponent<R> {
     fn type_path() -> &'static str {
-        std::any::type_name::<Self>()
+        static CELL: GenericTypePathCell = GenericTypePathCell::new();
+        CELL.get_or_insert::<Self, _>(|| {
+            format!(
+                "bevy_rand::component::EntropyComponent<{}>",
+                std::any::type_name::<R>()
+            )
+        })
     }
 
     fn short_type_path() -> &'static str {
         static CELL: GenericTypePathCell = GenericTypePathCell::new();
-        CELL.get_or_insert::<Self, _>(|| bevy::utils::get_short_name(std::any::type_name::<Self>()))
+        CELL.get_or_insert::<Self, _>(|| bevy::utils::get_short_name(Self::type_path()))
     }
 
     fn type_ident() -> Option<&'static str> {
@@ -247,6 +252,19 @@ mod tests {
         assert_ne!(
             rng1, rng2,
             "forked EntropyComponents should not match each other"
+        );
+    }
+
+    #[test]
+    fn type_paths() {
+        assert_eq!(
+            "bevy_rand::component::EntropyComponent<rand_chacha::chacha::ChaCha8Rng>",
+            EntropyComponent::<ChaCha8Rng>::type_path()
+        );
+
+        assert_eq!(
+            "EntropyComponent<ChaCha8Rng>",
+            EntropyComponent::<ChaCha8Rng>::short_type_path()
         );
     }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -2,8 +2,8 @@ use std::fmt::Debug;
 
 use crate::traits::SeedableEntropySource;
 use bevy::{
-    prelude::{FromReflect, Reflect, ReflectResource, Resource},
-    reflect::ReflectFromReflect,
+    prelude::{Reflect, ReflectFromReflect, ReflectResource, Resource},
+    reflect::{utility::GenericTypePathCell, TypePath},
 };
 use rand_core::{RngCore, SeedableRng};
 
@@ -32,7 +32,8 @@ use serde::{Deserialize, Serialize};
 ///   println!("Random value: {}", rng.next_u32());
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Resource, Reflect, FromReflect)]
+#[derive(Debug, Clone, PartialEq, Eq, Resource, Reflect)]
+#[reflect_value(type_path = false)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serialize",
@@ -62,6 +63,29 @@ impl<R: SeedableEntropySource + 'static> GlobalEntropy<R> {
     #[inline]
     pub fn reseed(&mut self, seed: R::Seed) {
         self.0 = R::from_seed(seed);
+    }
+}
+
+impl<R: SeedableEntropySource + 'static> TypePath for GlobalEntropy<R> {
+    fn type_path() -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
+    fn short_type_path() -> &'static str {
+        static CELL: GenericTypePathCell = GenericTypePathCell::new();
+        CELL.get_or_insert::<Self, _>(|| bevy::utils::get_short_name(std::any::type_name::<Self>()))
+    }
+
+    fn type_ident() -> Option<&'static str> {
+        Some("GlobalEntropy")
+    }
+
+    fn crate_name() -> Option<&'static str> {
+        Some("bevy_rand")
+    }
+
+    fn module_path() -> Option<&'static str> {
+        Some("bevy_rand::resource")
     }
 }
 

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -82,13 +82,16 @@ fn setup_sources(mut commands: Commands, mut rng: ResMut<GlobalEntropy<ChaCha8Rn
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_parallel_determinism() {
     App::new()
-        .add_plugin(EntropyPlugin::<ChaCha8Rng>::with_seed([2; 32]))
-        .add_startup_system(setup_sources)
-        .add_systems((
-            random_output_a,
-            random_output_b,
-            random_output_c,
-            random_output_d,
-        ))
+        .add_plugins(EntropyPlugin::<ChaCha8Rng>::with_seed([2; 32]))
+        .add_systems(Startup, setup_sources)
+        .add_systems(
+            Update,
+            (
+                random_output_a,
+                random_output_b,
+                random_output_c,
+                random_output_d,
+            ),
+        )
         .run();
 }


### PR DESCRIPTION
Due to `TypePath` requirements for reflection, `EntropyComponent`/`GlobalEntropy` must have custom `TypePath` implementations in order to still be able to wrap around `RngCore` structs without requiring upstream RNGs/`rand` crates to pull in bevy and implement `TypePath` themselves. This PR allows for the shim to continue to exist without forcing this requirement to upstream RNGs, nor forcing the crate to not impose `TypePath` trait constraints onto the generics, forcing all users to need to newtype their RNGs just to provide the `TypePath` trait.

# TODO
* [x] Target bevy `v0.11.1` once https://github.com/bevyengine/bevy/pull/9140 is merged and the patch version is released.
* [x] Update supported versions of bevy to `v0.11.1` for `v0.2`.