### PR TITLE
refactor: Forking via traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        run: cargo miri test --all-features
+        run: cargo miri test
         env:
           # -Zrandomize-layout makes sure we dont rely on the layout of anything that might change
           RUSTFLAGS: -Zrandomize-layout
@@ -102,4 +102,4 @@ jobs:
         run: rustup update ${{ env.MSRV }} --no-self-update && rustup default ${{ env.MSRV }}
       - name: Run cargo check
         id: check
-        run: cargo check --all-features
+        run: cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = ["bevy_prng"]
 
 [dependencies]
 # bevy
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "1258ceb62cd8acb61f031dce128c2e04ee058538", version = "0.12.0-dev", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "51c70bc98cd9c71d8e55a4656f22d0229a0ef06e", version = "0.12.0-dev", default-features = false }
 bevy_prng = { path = "bevy_prng", version = "0.2" }
 
 # others

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ rust-version = "1.70.0"
 default = ["serialize", "thread_local_entropy"]
 thread_local_entropy = ["dep:rand_chacha"]
 serialize = ["dep:serde", "rand_core/serde1"]
+rand_chacha = ["bevy_prng/rand_chacha"]
+rand_pcg = ["bevy_prng/rand_pcg"]
+rand_xoshiro = ["bevy_prng/rand_xoshiro"]
+wyrand = ["bevy_prng/wyrand"]
 
 [workspace]
 members = ["bevy_prng"]
@@ -51,3 +55,8 @@ getrandom = { version = "0.2", features = ["js"] }
 [[example]]
 name = "turn_based_game"
 path = "examples/turn_based_game.rs"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+rustc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rand"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "A plugin to integrate rand for ECS optimised RNG for the Bevy game engine."
@@ -22,7 +22,8 @@ members = ["bevy_prng"]
 
 [dependencies]
 # bevy
-bevy = { version = "0.11", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "1258ceb62cd8acb61f031dce128c2e04ee058538", version = "0.12.0-dev", default-features = false }
+bevy_prng = { path = "bevy_prng", version = "0.2" }
 
 # others
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -30,7 +31,7 @@ rand_core = { version = "0.6", features = ["std"] }
 rand_chacha = { version = "0.3", optional = true }
 
 [dev-dependencies]
-bevy_prng = { path = "bevy_prng", version = "0.1", features = ["rand_chacha"] }
+bevy_prng = { path = "bevy_prng", version = "0.2", features = ["rand_chacha"] }
 rand = "0.8"
 ron = { version = "0.8.0", features = ["integer128"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,15 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 rand_core = { version = "0.6", features = ["std"] }
 rand_chacha = { version = "0.3", optional = true }
 
+# This cfg cannot be enabled, but it forces Cargo to keep bevy_prng's
+# version in lockstep with bevy_rand, so that even minor versions
+# cannot be out of step with bevy_rand due to dependencies on traits
+# and implementations between the two crates.
+[target.'cfg(any())'.dependencies]
+bevy_prng = { path = "bevy_prng", version = "=0.2" }
+
 [dev-dependencies]
-bevy_prng = { path = "bevy_prng", version = "0.2", features = ["rand_chacha"] }
+bevy_prng = { path = "bevy_prng", version = "0.2", features = ["rand_chacha", "wyrand"] }
 rand = "0.8"
 ron = { version = "0.8.0", features = ["integer128"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = ["bevy_prng"]
 
 [dependencies]
 # bevy
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "51c70bc98cd9c71d8e55a4656f22d0229a0ef06e", version = "0.12.0-dev", default-features = false }
+bevy = { version = "0.12.0", default-features = false }
 bevy_prng = { path = "bevy_prng", version = "0.2" }
 
 # others

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -1,0 +1,21 @@
+# Migration Notes
+
+## Migrating from v0.2 to v0.3
+
+As v0.3 is a breaking change to v0.2, the process to migrate over is fairly simple. The rand algorithm crates can no longer be used directly, but they can be swapped wholesale with `bevy_prng` instead. So the following `Cargo.toml` changes:
+
+```diff
+- rand_chacha = { version = "0.3", features = ["serde1"] }
++ bevy_prng = { version = "0.1", features = ["rand_chacha"] }
+```
+
+allows then you to swap your import like so, which should then plug straight into existing `bevy_rand` usage seamlessly:
+
+```diff
+use bevy::prelude::*;
+use bevy_rand::prelude::*;
+- use rand_chacha::ChaCha8Rng;
++ use bevy_prng::ChaCha8Rng;
+```
+
+This **will** change the type path and the serialization format for the PRNGs, but currently, moving between different bevy versions has this problem as well as there's currently no means to migrate serialized formats from one version to another yet. The rationale for this change is to enable stable `TypePath` that is being imposed by bevy's reflection system, so that future compiler changes won't break things unexpectedly as `std::any::type_name` has no stability guarantees. Going forward, this should resolve any stability problems `bevy_rand` might have and be able to hook into any migration tool `bevy` might offer for when scene formats change/update.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Bevy Rand operates around a global entropy source provided as a resource, and th
 
 If cloning creates a second instance that shares the same state as the original, forking derives a new state from the original, leaving the original 'changed' and the new instance with a randomised seed. Forking RNG instances from a global source is a way to ensure that one seed produces many deterministic states, while making it difficult to predict outputs from many sources and also ensuring no one source shares the same state either with the original or with each other.
 
-Bevy Rand provides forking via `ForkableRng`/`ForkableAsRng`/`ForkableInnerRng` traits, allowing one to easily fork with just a simple `.fork_rng()` method call, making it straightforward to use. There's also `From` implementations, but from v0.4 onwards, these are considered deprecated and will likely be removed/changed in a future version.
+Bevy Rand provides forking via `ForkableRng`/`ForkableAsRng`/`ForkableInnerRng` traits, allowing one to easily fork with just a simple `.fork_rng()` method call, making it straightforward to use. There's also `From` implementations, **but from v0.4 onwards, these are considered deprecated and will likely be removed/changed in a future version**.
 
 ## Using Bevy Rand
 
@@ -205,25 +205,9 @@ If that extra level of security is not necessary, but there is still need for ex
 | v0.11  | v0.2, v0.3  |
 | v0.10  | v0.1        |
 
-## Migrating from v0.2 to v0.3
+## Migrations
 
-As v0.3 is a breaking change to v0.2, the process to migrate over is fairly simple. The rand algorithm crates can no longer be used directly, but they can be swapped wholesale with `bevy_prng` instead. So the following `Cargo.toml` changes:
-
-```diff
-- rand_chacha = { version = "0.3", features = ["serde1"] }
-+ bevy_prng = { version = "0.1", features = ["rand_chacha"] }
-```
-
-allows then you to swap your import like so, which should then plug straight into existing `bevy_rand` usage seamlessly:
-
-```diff
-use bevy::prelude::*;
-use bevy_rand::prelude::*;
-- use rand_chacha::ChaCha8Rng;
-+ use bevy_prng::ChaCha8Rng;
-```
-
-This **will** change the type path and the serialization format for the PRNGs, but currently, moving between different bevy versions has this problem as well as there's currently no means to migrate serialized formats from one version to another yet. The rationale for this change is to enable stable `TypePath` that is being imposed by bevy's reflection system, so that future compiler changes won't break things unexpectedly as `std::any::type_name` has no stability guarantees. Going forward, this should resolve any stability problems `bevy_rand` might have and be able to hook into any migration tool `bevy` might offer for when scene formats change/update.
+Notes on migrating between versions can be found [here](MIGRATIONS.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Bevy Rand operates around a global entropy source provided as a resource, and th
 
 If cloning creates a second instance that shares the same state as the original, forking derives a new state from the original, leaving the original 'changed' and the new instance with a randomised seed. Forking RNG instances from a global source is a way to ensure that one seed produces many deterministic states, while making it difficult to predict outputs from many sources and also ensuring no one source shares the same state either with the original or with each other.
 
-Bevy Rand provides forking via `ForkableRng`/`ForkableAsRng`/`ForkableInnerRng` traits, allowing one to easily fork with just a simple `.fork_rng()` method call, and also with `From` implementations of the various component/resource types, making it straightforward to use.
+Bevy Rand provides forking via `ForkableRng`/`ForkableAsRng`/`ForkableInnerRng` traits, allowing one to easily fork with just a simple `.fork_rng()` method call, making it straightforward to use. There's also `From` implementations, but from v0.4 onwards, these are considered deprecated and will likely be removed/changed in a future version.
 
 ## Using Bevy Rand
 

--- a/bevy_prng/Cargo.toml
+++ b/bevy_prng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_prng"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "A crate providing newtyped RNGs for integration into Bevy."
@@ -24,7 +24,7 @@ serialize = [
 ]
 
 [dependencies]
-bevy = { version = "0.11", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "1258ceb62cd8acb61f031dce128c2e04ee058538", version = "0.12.0-dev", default-features = false }
 rand_core = { version = "0.6", features = ["std"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 rand_chacha = { version = "0.3", optional = true }

--- a/bevy_prng/Cargo.toml
+++ b/bevy_prng/Cargo.toml
@@ -31,3 +31,8 @@ rand_chacha = { version = "0.3", optional = true }
 wyrand = { version = "0.1", optional = true }
 rand_pcg = { version = "0.3", optional = true }
 rand_xoshiro = { version = "0.6", optional = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+rustc-args = ["--cfg", "docsrs"]

--- a/bevy_prng/Cargo.toml
+++ b/bevy_prng/Cargo.toml
@@ -24,7 +24,7 @@ serialize = [
 ]
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "51c70bc98cd9c71d8e55a4656f22d0229a0ef06e", version = "0.12.0-dev", default-features = false }
+bevy = { version = "0.12.0", default-features = false }
 rand_core = { version = "0.6", features = ["std"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 rand_chacha = { version = "0.3", optional = true }

--- a/bevy_prng/Cargo.toml
+++ b/bevy_prng/Cargo.toml
@@ -24,7 +24,7 @@ serialize = [
 ]
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "1258ceb62cd8acb61f031dce128c2e04ee058538", version = "0.12.0-dev", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "51c70bc98cd9c71d8e55a4656f22d0229a0ef06e", version = "0.12.0-dev", default-features = false }
 rand_core = { version = "0.6", features = ["std"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 rand_chacha = { version = "0.3", optional = true }

--- a/bevy_prng/README.md
+++ b/bevy_prng/README.md
@@ -44,9 +44,10 @@ All the below crates implement the necessary traits to be compatible with `bevy_
 
 `bevy_prng` uses the same MSRV as `bevy`.
 
-| `bevy`   | `bevy_prng` |
-| -------- | ----------- |
-| v0.11    | v0.1        |
+| `bevy` | `bevy_prng` |
+| ------ | ----------- |
+| v0.12  | v0.2        |
+| v0.11  | v0.1        |
 
 ## License
 

--- a/bevy_prng/src/lib.rs
+++ b/bevy_prng/src/lib.rs
@@ -30,15 +30,7 @@ use bevy::prelude::ReflectFromReflect;
 ))]
 use bevy::prelude::{ReflectDeserialize, ReflectSerialize};
 
-#[cfg(all(
-    any(
-        feature = "wyrand",
-        feature = "rand_chacha",
-        feature = "rand_pcg",
-        feature = "rand_xoshiro"
-    ),
-    feature = "serialize"
-))]
+#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 /// A marker trait to define the required trait bounds for a seedable PRNG to

--- a/examples/turn_based_game.rs
+++ b/examples/turn_based_game.rs
@@ -74,7 +74,7 @@ fn setup_player(mut commands: Commands, mut rng: ResMut<GlobalEntropy<ChaCha8Rng
         // Forking from the global instance creates a random, but deterministic
         // seed for the component, making it hard to guess yet still have a
         // deterministic output
-        EntropyComponent::from(&mut rng),
+        rng.fork_rng(),
     ));
 }
 
@@ -96,7 +96,7 @@ fn setup_enemies(mut commands: Commands, mut rng: ResMut<GlobalEntropy<ChaCha8Rn
             // Forking from the global instance creates a random, but deterministic
             // seed for the component, making it hard to guess yet still have a
             // deterministic output
-            EntropyComponent::from(&mut rng),
+            rng.fork_rng(),
         ));
     }
 }

--- a/src/component.rs
+++ b/src/component.rs
@@ -250,6 +250,18 @@ mod tests {
     }
 
     #[test]
+    fn forking_inner() {
+        let mut rng1 = EntropyComponent::<ChaCha8Rng>::default();
+
+        let rng2 = rng1.fork_inner();
+
+        assert_ne!(
+            rng1.0, rng2,
+            "forked ChaCha8Rngs should not match each other"
+        );
+    }
+
+    #[test]
     fn type_paths() {
         assert_eq!(
             "bevy_rand::component::EntropyComponent<bevy_prng::ChaCha8Rng>",

--- a/src/component.rs
+++ b/src/component.rs
@@ -233,7 +233,7 @@ where
 #[cfg(test)]
 mod tests {
     use bevy::reflect::TypePath;
-    use bevy_prng::ChaCha8Rng;
+    use bevy_prng::{ChaCha8Rng, ChaCha12Rng};
 
     use super::*;
 
@@ -247,6 +247,18 @@ mod tests {
             rng1, rng2,
             "forked EntropyComponents should not match each other"
         );
+    }
+
+    #[test]
+    fn forking_as() {
+        let mut rng1 = EntropyComponent::<ChaCha12Rng>::default();
+
+        let rng2 = rng1.fork_as::<ChaCha8Rng>();
+
+        let rng1 = format!("{:?}", rng1);
+        let rng2 = format!("{:?}", rng2);
+
+        assert_ne!(&rng1, &rng2, "forked EntropyComponents should not match each other");
     }
 
     #[test]

--- a/src/component.rs
+++ b/src/component.rs
@@ -59,7 +59,7 @@ use serde::{Deserialize, Serialize};
 ///     commands
 ///         .spawn((
 ///             Source,
-///             EntropyComponent::from(&mut global),
+///             global.fork_rng(),
 ///         ));
 /// }
 /// ```
@@ -85,7 +85,7 @@ use serde::{Deserialize, Serialize};
 ///        commands
 ///            .spawn((
 ///                Npc,
-///                EntropyComponent::from(&mut source)
+///                source.fork_rng()
 ///            ));
 ///    }
 /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,5 @@ pub mod prelude;
 pub mod resource;
 #[cfg(feature = "thread_local_entropy")]
 mod thread_local_entropy;
-mod traits;
+/// Traits for enabling utility methods for [`crate::component::EntropyComponent`] and [`crate::resource::GlobalEntropy`].
+pub mod traits;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,5 +1,6 @@
-use crate::{component::EntropyComponent, resource::GlobalEntropy, traits::SeedableEntropySource};
+use crate::{component::EntropyComponent, resource::GlobalEntropy};
 use bevy::prelude::{App, Plugin};
+use bevy_prng::SeedableEntropySource;
 use rand_core::SeedableRng;
 
 /// Plugin for integrating a PRNG that implements `RngCore` into

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
 pub use crate::component::EntropyComponent;
 pub use crate::plugin::EntropyPlugin;
 pub use crate::resource::GlobalEntropy;
-pub use crate::traits::{EcsEntropySource, ForkableAsRng, ForkableInnerRng, ForkableRng};
+pub use crate::traits::{ForkableAsRng, ForkableInnerRng, ForkableRng};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,3 +2,22 @@ pub use crate::component::EntropyComponent;
 pub use crate::plugin::EntropyPlugin;
 pub use crate::resource::GlobalEntropy;
 pub use crate::traits::{ForkableAsRng, ForkableInnerRng, ForkableRng};
+#[cfg(feature = "wyrand")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
+pub use bevy_prng::WyRand;
+
+#[cfg(feature = "rand_chacha")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_chacha")))]
+pub use bevy_prng::{ChaCha12Rng, ChaCha20Rng, ChaCha8Rng};
+
+#[cfg(feature = "rand_pcg")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_pcg")))]
+pub use bevy_prng::{Pcg32, Pcg64, Pcg64Mcg};
+
+#[cfg(feature = "rand_xoshiro")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_xoshiro")))]
+pub use bevy_prng::{
+    Xoroshiro128Plus, Xoroshiro128PlusPlus, Xoroshiro128StarStar, Xoroshiro64Star,
+    Xoroshiro64StarStar, Xoshiro128Plus, Xoshiro128PlusPlus, Xoshiro128StarStar, Xoshiro256Plus,
+    Xoshiro256PlusPlus, Xoshiro256StarStar, Xoshiro512Plus, Xoshiro512PlusPlus, Xoshiro512StarStar,
+};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
 pub use crate::component::EntropyComponent;
 pub use crate::plugin::EntropyPlugin;
 pub use crate::resource::GlobalEntropy;
-pub use crate::traits::SeedableEntropySource;
+pub use crate::traits::{EcsEntropySource, ForkableAsRng, ForkableInnerRng, ForkableRng};

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,7 +1,11 @@
 use std::fmt::Debug;
 
-use crate::traits::SeedableEntropySource;
+use crate::{
+    component::EntropyComponent,
+    traits::{EcsEntropySource, ForkableAsRng, ForkableInnerRng, ForkableRng},
+};
 use bevy::prelude::{Reflect, ReflectFromReflect, ReflectResource, Resource};
+use bevy_prng::SeedableEntropySource;
 use rand_core::{RngCore, SeedableRng};
 
 #[cfg(feature = "thread_local_entropy")]
@@ -120,6 +124,8 @@ impl<R: SeedableEntropySource + 'static> SeedableRng for GlobalEntropy<R> {
     }
 }
 
+impl<R: SeedableEntropySource + 'static> EcsEntropySource for GlobalEntropy<R> {}
+
 impl<R: SeedableEntropySource + 'static> From<R> for GlobalEntropy<R> {
     fn from(value: R) -> Self {
         Self::new(value)
@@ -130,6 +136,27 @@ impl<R: SeedableEntropySource + 'static> From<&mut R> for GlobalEntropy<R> {
     fn from(value: &mut R) -> Self {
         Self::from_rng(value).unwrap()
     }
+}
+
+impl<R> ForkableRng for GlobalEntropy<R>
+where
+    R: SeedableEntropySource + 'static,
+{
+    type Output = EntropyComponent<R>;
+}
+
+impl<R> ForkableAsRng for GlobalEntropy<R>
+where
+    R: SeedableEntropySource + 'static,
+{
+    type Output<T> = EntropyComponent<T> where T: SeedableEntropySource;
+}
+
+impl<R> ForkableInnerRng for GlobalEntropy<R>
+where
+    R: SeedableEntropySource + 'static,
+{
+    type Output = R;
 }
 
 #[cfg(test)]
@@ -152,17 +179,30 @@ mod tests {
         );
     }
 
+    #[test]
+    fn forking_into_component() {
+        let mut source: GlobalEntropy<ChaCha8Rng> = GlobalEntropy::<ChaCha8Rng>::from_seed([1; 32]);
+
+        let mut forked = source.fork_rng();
+
+        let source_val = source.next_u32();
+
+        let forked_val = forked.next_u32();
+
+        assert_ne!(source_val, forked_val);
+    }
+
     #[cfg(feature = "serialize")]
     #[test]
     fn rng_untyped_serialization() {
         use bevy::reflect::{
             serde::{ReflectSerializer, UntypedReflectDeserializer},
-            TypeRegistryInternal,
+            TypeRegistry,
         };
         use ron::ser::to_string;
         use serde::de::DeserializeSeed;
 
-        let mut registry = TypeRegistryInternal::default();
+        let mut registry = TypeRegistry::default();
         registry.register::<GlobalEntropy<ChaCha8Rng>>();
 
         let mut val = GlobalEntropy::<ChaCha8Rng>::from_seed([7; 32]);
@@ -205,12 +245,12 @@ mod tests {
     fn rng_typed_serialization() {
         use bevy::reflect::{
             serde::{TypedReflectDeserializer, TypedReflectSerializer},
-            GetTypeRegistration, TypeRegistryInternal,
+            GetTypeRegistration, TypeRegistry,
         };
         use ron::to_string;
         use serde::de::DeserializeSeed;
 
-        let mut registry = TypeRegistryInternal::default();
+        let mut registry = TypeRegistry::default();
         registry.register::<GlobalEntropy<ChaCha8Rng>>();
 
         let registered_type = GlobalEntropy::<ChaCha8Rng>::get_type_registration();

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -162,7 +162,7 @@ where
 #[cfg(test)]
 mod tests {
     use bevy::reflect::TypePath;
-    use bevy_prng::ChaCha8Rng;
+    use bevy_prng::{ChaCha8Rng, ChaCha12Rng};
 
     use super::*;
 
@@ -190,6 +190,18 @@ mod tests {
         let forked_val = forked.next_u32();
 
         assert_ne!(source_val, forked_val);
+    }
+
+    #[test]
+    fn forking_as() {
+        let mut rng1 = GlobalEntropy::<ChaCha12Rng>::default();
+
+        let rng2 = rng1.fork_as::<ChaCha8Rng>();
+
+        let rng1 = format!("{:?}", rng1);
+        let rng2 = format!("{:?}", rng2);
+
+        assert_ne!(&rng1, &rng2, "GlobalEntropy should not match the forked component");
     }
 
     #[test]

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -162,7 +162,7 @@ where
 #[cfg(test)]
 mod tests {
     use bevy::reflect::TypePath;
-    use bevy_prng::{ChaCha8Rng, ChaCha12Rng};
+    use bevy_prng::{ChaCha8Rng, ChaCha12Rng, WyRand};
 
     use super::*;
 
@@ -196,7 +196,7 @@ mod tests {
     fn forking_as() {
         let mut rng1 = GlobalEntropy::<ChaCha12Rng>::default();
 
-        let rng2 = rng1.fork_as::<ChaCha8Rng>();
+        let rng2 = rng1.fork_as::<WyRand>();
 
         let rng1 = format!("{:?}", rng1);
         let rng2 = format!("{:?}", rng2);

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -192,6 +192,18 @@ mod tests {
         assert_ne!(source_val, forked_val);
     }
 
+    #[test]
+    fn forking_inner() {
+        let mut rng1 = GlobalEntropy::<ChaCha8Rng>::default();
+
+        let rng2 = rng1.fork_inner();
+
+        assert_ne!(
+            rng1.0, rng2,
+            "forked ChaCha8Rngs should not match each other"
+        );
+    }
+
     #[cfg(feature = "serialize")]
     #[test]
     fn rng_untyped_serialization() {

--- a/src/thread_local_entropy.rs
+++ b/src/thread_local_entropy.rs
@@ -24,7 +24,7 @@ impl ThreadLocalEntropy {
     #[inline]
     #[must_use]
     pub(crate) fn new() -> Self {
-        Self(SOURCE.with(|source| Rc::clone(source)))
+        Self(SOURCE.with(Rc::clone))
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,6 +10,22 @@ pub trait ForkableRng: EcsEntropySource {
 
     /// Fork the original instance to yield a new instance with a generated seed.
     /// This method preserves the RNG algorithm between original and forked instances.
+    /// ```
+    /// use bevy::prelude::*;
+    /// use bevy_rand::prelude::*;
+    /// use bevy_prng::ChaCha8Rng;
+    ///
+    /// #[derive(Component)]
+    /// struct Source;
+    ///
+    /// fn setup_source(mut commands: Commands, mut global: ResMut<GlobalEntropy<ChaCha8Rng>>) {
+    ///     commands
+    ///         .spawn((
+    ///             Source,
+    ///             global.fork_rng(),
+    ///         ));
+    /// }
+    /// ```
     fn fork_rng(&mut self) -> Self::Output {
         Self::Output::from_rng(self).unwrap()
     }
@@ -26,6 +42,22 @@ pub trait ForkableAsRng: EcsEntropySource {
 
     /// Fork the original instance to yield a new instance with a generated seed.
     /// This method allows one to specify the RNG algorithm to be used for the forked instance.
+    /// ```
+    /// use bevy::prelude::*;
+    /// use bevy_rand::prelude::*;
+    /// use bevy_prng::{ChaCha8Rng, ChaCha12Rng};
+    ///
+    /// #[derive(Component)]
+    /// struct Source;
+    ///
+    /// fn setup_source(mut commands: Commands, mut global: ResMut<GlobalEntropy<ChaCha12Rng>>) {
+    ///     commands
+    ///         .spawn((
+    ///             Source,
+    ///             global.fork_as::<ChaCha8Rng>(),
+    ///         ));
+    /// }
+    /// ```
     fn fork_as<T: SeedableEntropySource>(&mut self) -> Self::Output<T> {
         Self::Output::<_>::from_rng(self).unwrap()
     }
@@ -40,6 +72,25 @@ pub trait ForkableInnerRng: EcsEntropySource {
 
     /// Fork the original instance to yield a new instance with a generated seed.
     /// This method yields the inner PRNG instance directly as a forked instance.
+    /// ```
+    /// use bevy::prelude::*;
+    /// use bevy_rand::prelude::*;
+    /// use bevy_prng::ChaCha8Rng;
+    /// use rand_core::RngCore;
+    ///
+    /// #[derive(Component)]
+    /// struct Source;
+    ///
+    /// fn do_random_action(source: &mut ChaCha8Rng) {
+    ///     println!("Random value: {}", source.next_u32());
+    /// }
+    ///
+    /// fn access_source(mut global: ResMut<GlobalEntropy<ChaCha8Rng>>) {
+    ///     let mut source = global.fork_inner();
+    ///
+    ///     do_random_action(&mut source);
+    /// }
+    /// ```
     fn fork_inner(&mut self) -> Self::Output {
         Self::Output::from_rng(self).unwrap()
     }

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -60,13 +60,13 @@ fn random_output_d(mut q_source: Query<&mut EntropyComponent<ChaCha8Rng>, With<S
 }
 
 fn setup_sources(mut commands: Commands, mut rng: ResMut<GlobalEntropy<ChaCha8Rng>>) {
-    commands.spawn((SourceA, EntropyComponent::from(&mut rng)));
+    commands.spawn((SourceA, rng.fork_as::<ChaCha8Rng>()));
 
-    commands.spawn((SourceB, EntropyComponent::from(&mut rng)));
+    commands.spawn((SourceB, rng.fork_rng()));
 
-    commands.spawn((SourceC, EntropyComponent::from(&mut rng)));
+    commands.spawn((SourceC, rng.fork_rng()));
 
-    commands.spawn((SourceD, EntropyComponent::from(&mut rng)));
+    commands.spawn((SourceD, rng.fork_rng()));
 }
 
 /// Entities having their own sources side-steps issues with parallel execution and scheduling

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::type_complexity)]
 
 use bevy::prelude::*;
-use bevy_prng::ChaCha8Rng;
+use bevy_prng::{ChaCha8Rng, WyRand, ChaCha12Rng};
 use bevy_rand::prelude::*;
 use rand::prelude::Rng;
 
+use rand_core::RngCore;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 
@@ -22,6 +23,9 @@ struct SourceC;
 
 #[derive(Component)]
 struct SourceD;
+
+#[derive(Component)]
+struct SourceE;
 
 fn random_output_a(mut q_source: Query<&mut EntropyComponent<ChaCha8Rng>, With<SourceA>>) {
     let mut rng = q_source.single_mut();
@@ -49,24 +53,40 @@ fn random_output_c(mut q_source: Query<&mut EntropyComponent<ChaCha8Rng>, With<S
     );
 }
 
-fn random_output_d(mut q_source: Query<&mut EntropyComponent<ChaCha8Rng>, With<SourceD>>) {
+fn random_output_d(mut q_source: Query<&mut EntropyComponent<ChaCha12Rng>, With<SourceD>>) {
     let mut rng = q_source.single_mut();
 
     assert_eq!(
         rng.gen::<(u16, u16)>(),
-        (61569, 26940),
+        (41421, 7891),
         "SourceD does not match expected output"
     );
 }
 
+fn random_output_e(mut q_source: Query<&mut EntropyComponent<WyRand>, With<SourceE>>) {
+    let mut rng = q_source.single_mut();
+
+    let mut bytes = [0u8; 8];
+
+    rng.fill_bytes(bytes.as_mut());
+
+    assert_eq!(
+        &bytes,
+        &[195, 159, 73, 157, 39, 99, 104, 111],
+        "SourceE does not match expected output"
+    );
+}
+
 fn setup_sources(mut commands: Commands, mut rng: ResMut<GlobalEntropy<ChaCha8Rng>>) {
-    commands.spawn((SourceA, rng.fork_as::<ChaCha8Rng>()));
+    commands.spawn((SourceA, rng.fork_rng()));
 
     commands.spawn((SourceB, rng.fork_rng()));
 
     commands.spawn((SourceC, rng.fork_rng()));
 
-    commands.spawn((SourceD, rng.fork_rng()));
+    commands.spawn((SourceD, rng.fork_as::<ChaCha12Rng>()));
+
+    commands.spawn((SourceE, rng.fork_as::<WyRand>()));
 }
 
 /// Entities having their own sources side-steps issues with parallel execution and scheduling
@@ -91,6 +111,7 @@ fn test_parallel_determinism() {
                 random_output_b,
                 random_output_c,
                 random_output_d,
+                random_output_e,
             ),
         )
         .run();


### PR DESCRIPTION
The Forking Refactor, where instead of `From` implementations (which did allow for control over how one created new PRNG instances), various traits to provide forking methods have been provided instead to simplify the process of forking from a `GlobalEntropy` source to `EntropyComponent`, and also for `EntropyComponent` to `EntropyComponent`. The refactor also covers cases where forking between different algorithm types, as well as forking the inner PRNG instances of `GlobalEntropy`/`EntropyComponent`.

- `fork_rng()` - This is the simplest method, forks with the same PRNG between original and forked instances. I'm more partial to shortening to `fork` however, as that is seen elsewhere in `fastrand` and `turborand`.
- `fork_as()` - This method allows forking to a specified PRNG algorithm, so if a user with a `GlobalEntropy<ChaCha8Rng>` wants to fork an `EntropyComponent<WyRand>`, they can do so via `.fork_as::<WyRand>()`.
- `fork_inner()` - This method allows one to fork the inner instance directly, so `GlobalEntropy<ChaCha8Rng>` will fork a `ChaCha8Rng` instance.

This PR also includes prep for the next Bevy version.

# Todos/
- [x] Iterate on documentation, provide more examples
- [x] More tests to cover the different forking methods.

Closes #10 