### PR TITLE
feat: Better thread local access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/Bluefinger/bevy_rand"
 license = "MIT OR Apache-2.0"
-version = "0.5.1"
+version = "0.5.2"
 rust-version = "1.76.0"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ bevy_rand = "0.5"
 bevy_prng = { version = "0.5", features = ["rand_chacha", "wyrand"] }
 ```
 
-The summary of what RNG algorithm to choose is: pick `wyrand` for almost all cases as it is faster and more portable than other algorithms. For cases where you need the extra assurance of entropy quality (for security, etc), then use `rand_chacha`. For more information, [go here](https://docs.rs/bevy_rand/latest/bevy_rand/tutorial/chapter01_choosing_prng/index.html).
+The summary of what RNG algorithm to choose is: pick `wyrand` for almost all cases as it is faster and more portable than other algorithms. For cases where you need the extra assurance of entropy quality (for security, etc), then use `rand_chacha`. For more information, [go here](https://docs.rs/bevy_rand/latest/bevy_rand/tutorial/ch01_choosing_prng/index.html).
 
 ### Registering a PRNG for use with Bevy Rand
 

--- a/bevy_prng/src/newtype.rs
+++ b/bevy_prng/src/newtype.rs
@@ -21,7 +21,7 @@ macro_rules! newtype_prng {
 
         impl $newtype {
             /// Create a new instance.
-            #[inline]
+            #[inline(always)]
             #[must_use]
             pub fn new(rng: $rng) -> Self {
                 Self(rng)

--- a/src/thread_local_entropy.rs
+++ b/src/thread_local_entropy.rs
@@ -15,7 +15,6 @@ thread_local! {
 /// [Too Much Crypto](https://eprint.iacr.org/2019/1492.pdf) paper. [`ThreadLocalEntropy`] is not thread-safe and
 /// cannot be sent or synchronised between threads, it should be initialised within each thread context it is
 /// needed in.
-#[derive(Clone)]
 pub(crate) struct ThreadLocalEntropy(PhantomData<*mut ()>);
 
 impl ThreadLocalEntropy {
@@ -89,10 +88,8 @@ mod tests {
         let mut bytes1 = vec![0u8; 128];
         let mut bytes2 = vec![0u8; 128];
 
-        let mut cloned = rng1.clone();
-
         rng1.fill_bytes(&mut bytes1);
-        cloned.fill_bytes(&mut bytes2);
+        rng2.fill_bytes(&mut bytes2);
 
         // Cloned ThreadLocalEntropy instances won't output the same entropy
         assert_ne!(&bytes1, &bytes2);

--- a/src/thread_local_entropy.rs
+++ b/src/thread_local_entropy.rs
@@ -25,6 +25,12 @@ impl ThreadLocalEntropy {
         Self(PhantomData)
     }
 
+    /// Initiates an access to the thread local source, passing a `&mut ChaCha8Rng` to the
+    /// closure.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the thread destructor is running or has been previously run.
     #[inline]
     fn access_local_source<F, O>(&mut self, f: F) -> O
     where

--- a/src/thread_local_entropy.rs
+++ b/src/thread_local_entropy.rs
@@ -91,7 +91,8 @@ mod tests {
         rng1.fill_bytes(&mut bytes1);
         rng2.fill_bytes(&mut bytes2);
 
-        // Cloned ThreadLocalEntropy instances won't output the same entropy
+        // ThreadLocalEntropy instances won't output the same entropy as the
+        // underlying thread local source gets mutated each access.
         assert_ne!(&bytes1, &bytes2);
     }
 


### PR DESCRIPTION
The original implementation of `ThreadLocalEntropy` was based on `rand`'s `ThreadRng`, making a few changes to not require reseeding or forking protection in order to assume cases more in-line with game application usage. However, as a result, it picked up the issues with the original implementation, such as leaking memory if the destructors for `ThreadLocalEntropy` didn't run.

This new implementation does away with cloning an `Rc` reference, instead opting for keeping the references within the `LocalKey::with` closure, avoiding any reference counting. The `Rc` prevents premature freeing during thread-local destructors, while keeping the ref inside the `with` closure ensures that we never end up in a situation where we might have a ref counted instance that never gets cleaned up.

This also apparently allows the compiler to make better optimisations with the thread local access. Normal release profile has the perf for the old implementation and new implementation around the same, with the new implementation slightly ahead for the worst case scenario and with better mean/median times. With `codegen-units = 1` and LTO, it optimises considerably better.

**NOTE**: This is tuned for the specific usage of `ThreadLocalEntropy` within `bevy_rand`. For *one time* accesses with `ThreadLocalEntropy` that then use the RNG source before dropping, this implementation is much faster. For accesses that hold the reference for longer to be used repeatedly before dropping, the original `ThreadRng` implementation is faster. `bevy_rand`'s case is more on the one-time accesses.