### PR TITLE
chore: Update to latest wyrand version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/Bluefinger/bevy_rand"
 license = "MIT OR Apache-2.0"
-version = "0.5.2"
+version = "0.6.0"
 rust-version = "1.76.0"
 
 [workspace.dependencies]
@@ -16,7 +16,7 @@ serde = "1"
 serde_derive = "1"
 rand_core = { version = "0.6", features = ["std"] }
 rand_chacha = "0.3"
-wyrand = "0.1"
+wyrand = "0.2"
 rand_pcg = "0.3"
 rand_xoshiro = "0.6"
 
@@ -45,7 +45,7 @@ wyrand = ["bevy_prng/wyrand"]
 [dependencies]
 # bevy
 bevy.workspace = true
-bevy_prng = { path = "bevy_prng", version = "0.5" }
+bevy_prng = { path = "bevy_prng", version = "0.6" }
 
 # others
 rand_core.workspace = true
@@ -58,10 +58,10 @@ serde_derive = { workspace = true, optional = true }
 # cannot be out of step with bevy_rand due to dependencies on traits
 # and implementations between the two crates.
 [target.'cfg(any())'.dependencies]
-bevy_prng = { path = "bevy_prng", version = "=0.5" }
+bevy_prng = { path = "bevy_prng", version = "=0.6" }
 
 [dev-dependencies]
-bevy_prng = { path = "bevy_prng", version = "0.5", features = ["rand_chacha", "wyrand"] }
+bevy_prng = { path = "bevy_prng", version = "0.6", features = ["rand_chacha", "wyrand"] }
 rand = "0.8"
 ron = { version = "0.8.0", features = ["integer128"] }
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -19,3 +19,7 @@ use bevy_rand::prelude::*;
 ```
 
 This **will** change the type path and the serialization format for the PRNGs, but currently, moving between different bevy versions has this problem as well as there's currently no means to migrate serialized formats from one version to another yet. The rationale for this change is to enable stable `TypePath` that is being imposed by bevy's reflection system, so that future compiler changes won't break things unexpectedly as `std::any::type_name` has no stability guarantees. Going forward, this should resolve any stability problems `bevy_rand` might have and be able to hook into any migration tool `bevy` might offer for when scene formats change/update.
+
+## Migrating from v0.5 to v0.6
+
+As the wyrand dependency has been updated and contains a breaking output change, users of `bevy_rand` making use of the `wyrand` feature will need to update their code in cases where deterministic output from the old version is expected. The new `WyRand` output is considered to provide better entropy than the old version, so it is recommended to adopt the new version. In reality, this is likely to affect tests and serialised output rather than game code.

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -22,4 +22,4 @@ This **will** change the type path and the serialization format for the PRNGs, b
 
 ## Migrating from v0.5 to v0.6
 
-As the wyrand dependency has been updated and contains a breaking output change, users of `bevy_rand` making use of the `wyrand` feature will need to update their code in cases where deterministic output from the old version is expected. The new `WyRand` output is considered to provide better entropy than the old version, so it is recommended to adopt the new version. In reality, this is likely to affect tests and serialised output rather than game code.
+As the `wyrand` dependency has been updated and contains a breaking output change, users of `bevy_rand` making use of the `wyrand` feature will need to update their code in cases where deterministic output from the old version is expected. The new `WyRand` output is considered to provide better entropy than the old version, so it is recommended to adopt the new version. In reality, this is likely to affect tests and serialised output rather than game code.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ fn setup_npc_from_source(
 
 | `bevy` | `bevy_rand` |
 | ------ | ----------- |
-| v0.13  | v0.5        |
+| v0.13  | v0.5, v0.6  |
 | v0.12  | v0.4        |
 | v0.11  | v0.2, v0.3  |
 | v0.10  | v0.1        |
@@ -137,7 +137,7 @@ The versions of `rand_core`/`rand` that `bevy_rand` is compatible with is as fol
 
 | `bevy_rand`  | `rand_core` | `rand` |
 | ------------ | ----------- | ------ |
-| v0.1 -> v0.5 | v0.6        | v0.8   |
+| v0.1 -> v0.6 | v0.6        | v0.8   |
 
 ## Migrations
 

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -74,7 +74,7 @@ fn random_output_e(mut q_source: Query<&mut EntropyComponent<WyRand>, With<Sourc
 
     assert_eq!(
         &bytes,
-        &[195, 159, 73, 157, 39, 99, 104, 111],
+        &[42, 244, 101, 178, 244, 252, 72, 104],
         "SourceE does not match expected output"
     );
 }


### PR DESCRIPTION
Updates to the latest version of the `wyrand` dependency. Because it is a breaking change output-wise, `bevy_rand` is being updated to a new major version to maintain semver guarantees.