### PR TITLE
feat: add GlobalRngSeed resource for tracking initial state/seed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/Bluefinger/bevy_rand"
 license = "MIT OR Apache-2.0"
-version = "0.6.0"
+version = "0.7.0"
 rust-version = "1.76.0"
 
 [workspace.dependencies]
@@ -45,9 +45,10 @@ wyrand = ["bevy_prng/wyrand"]
 [dependencies]
 # bevy
 bevy.workspace = true
-bevy_prng = { path = "bevy_prng", version = "0.6" }
+bevy_prng = { path = "bevy_prng", version = "0.7" }
 
 # others
+getrandom = "0.2"
 rand_core.workspace = true
 rand_chacha = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -58,10 +59,10 @@ serde_derive = { workspace = true, optional = true }
 # cannot be out of step with bevy_rand due to dependencies on traits
 # and implementations between the two crates.
 [target.'cfg(any())'.dependencies]
-bevy_prng = { path = "bevy_prng", version = "=0.6" }
+bevy_prng = { path = "bevy_prng", version = "=0.7" }
 
 [dev-dependencies]
-bevy_prng = { path = "bevy_prng", version = "0.6", features = ["rand_chacha", "wyrand"] }
+bevy_prng = { path = "bevy_prng", version = "0.7", features = ["rand_chacha", "wyrand"] }
 rand = "0.8"
 ron = { version = "0.8.0", features = ["integer128"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub mod plugin;
 pub mod prelude;
 /// Resource for integrating [`RngCore`] PRNGs into bevy. Must be newtyped to support [`Reflect`].
 pub mod resource;
+/// Seed Resource for seeding [`crate::resource::GlobalEntropy`].
+pub mod seed;
 #[cfg(feature = "thread_local_entropy")]
 mod thread_local_entropy;
 /// Traits for enabling utility methods for [`crate::component::EntropyComponent`] and [`crate::resource::GlobalEntropy`].

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,7 @@
 pub use crate::component::EntropyComponent;
 pub use crate::plugin::EntropyPlugin;
 pub use crate::resource::GlobalEntropy;
+pub use crate::seed::GlobalRngSeed;
 pub use crate::traits::{ForkableAsRng, ForkableInnerRng, ForkableRng};
 #[cfg(feature = "wyrand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,0 +1,150 @@
+use std::marker::PhantomData;
+
+use bevy::{
+    app::App,
+    ecs::system::Resource,
+    reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath},
+};
+use bevy_prng::SeedableEntropySource;
+use rand_core::RngCore;
+
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Resource, Reflect)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
+#[cfg_attr(
+    feature = "serialize",
+    serde(bound(deserialize = "R::Seed: Serialize + for<'a> Deserialize<'a>"))
+)]
+/// Resource for storing the initial seed used to initialize a [`crate::resource::GlobalEntropy`].
+/// Useful for tracking the starting seed or for forcing [`crate::resource::GlobalEntropy`] to reseed.
+pub struct GlobalRngSeed<R: SeedableEntropySource> {
+    seed: R::Seed,
+    #[reflect(ignore)]
+    rng: PhantomData<R>,
+}
+
+impl<R: SeedableEntropySource> GlobalRngSeed<R>
+where
+    R::Seed: Sync + Send + Clone + Reflect + GetTypeRegistration + FromReflect + TypePath,
+{
+    /// Helper method to register the necessary types for [`Reflect`] purposes. Ensures
+    /// that not only the main type is registered, but also the correct seed type for the
+    /// PRNG.
+    pub fn register_type(app: &mut App) {
+        app.register_type::<Self>();
+        app.register_type::<R::Seed>();
+    }
+}
+
+impl<R: SeedableEntropySource> GlobalRngSeed<R>
+where
+    R::Seed: Sync + Send + Clone,
+{
+    /// Create a new instance of [`GlobalRngSeed`].
+    #[inline]
+    #[must_use]
+    pub fn new(seed: R::Seed) -> Self {
+        Self {
+            seed,
+            rng: PhantomData,
+        }
+    }
+
+    /// Returns a cloned instance of the seed value.
+    #[inline]
+    pub fn get_seed(&self) -> R::Seed {
+        self.seed.clone()
+    }
+
+    /// Initializes an instance of [`GlobalRngSeed`] with a randomised seed
+    /// value, drawn from thread-local or OS sources.
+    #[inline]
+    pub fn from_entropy() -> Self {
+        let mut seed = Self::new(R::Seed::default());
+
+        #[cfg(feature = "thread_local_entropy")]
+        {
+            use crate::thread_local_entropy::ThreadLocalEntropy;
+
+            ThreadLocalEntropy::new().fill_bytes(seed.as_mut());
+        }
+        #[cfg(not(feature = "thread_local_entropy"))]
+        {
+            use getrandom::getrandom;
+
+            getrandom(seed.as_mut()).expect("Unable to source entropy for seeding");
+        }
+
+        seed
+    }
+}
+
+impl<R: SeedableEntropySource> Default for GlobalRngSeed<R>
+where
+    R::Seed: Sync + Send + Clone,
+{
+    #[inline]
+    fn default() -> Self {
+        Self::from_entropy()
+    }
+}
+
+impl<R: SeedableEntropySource> AsMut<[u8]> for GlobalRngSeed<R>
+where
+    R::Seed: Sync + Send + Clone,
+{
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.seed.as_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "serialize")]
+    #[test]
+    fn reflection_serialization_round_trip_works() {
+        use bevy::reflect::{
+            serde::{TypedReflectDeserializer, TypedReflectSerializer},
+            GetTypeRegistration, TypeRegistry,
+        };
+        use bevy_prng::WyRand;
+        use ron::to_string;
+        use serde::de::DeserializeSeed;
+
+        let mut registry = TypeRegistry::default();
+        registry.register::<GlobalRngSeed<WyRand>>();
+        registry.register::<[u8; 8]>();
+
+        let registered_type = GlobalRngSeed::<WyRand>::get_type_registration();
+
+        let val = GlobalRngSeed::<WyRand>::new(u64::MAX.to_ne_bytes());
+
+        let ser = TypedReflectSerializer::new(&val, &registry);
+
+        let serialized = to_string(&ser).unwrap();
+
+        assert_eq!(&serialized, "(seed:(255,255,255,255,255,255,255,255))");
+
+        let mut deserializer = ron::Deserializer::from_str(&serialized).unwrap();
+
+        let de = TypedReflectDeserializer::new(&registered_type, &registry);
+
+        let value = de.deserialize(&mut deserializer).unwrap();
+
+        assert!(value.is_dynamic());
+        assert!(value.represents::<GlobalRngSeed<WyRand>>());
+        assert!(!value.is::<GlobalRngSeed<WyRand>>());
+
+        let recreated = GlobalRngSeed::<WyRand>::from_reflect(value.as_reflect()).unwrap();
+
+        assert_eq!(val.get_seed(), recreated.get_seed());
+    }
+}

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::*;
 use bevy_prng::{ChaCha12Rng, ChaCha8Rng, WyRand};
 use bevy_rand::prelude::{
-    EntropyComponent, EntropyPlugin, ForkableAsRng, ForkableRng, GlobalEntropy,
+    EntropyComponent, EntropyPlugin, ForkableAsRng, ForkableRng, GlobalEntropy, GlobalRngSeed,
 };
 use rand::prelude::Rng;
 
@@ -91,6 +91,10 @@ fn setup_sources(mut commands: Commands, mut rng: ResMut<GlobalEntropy<ChaCha8Rn
     commands.spawn((SourceE, rng.fork_as::<WyRand>()));
 }
 
+fn read_global_seed(seed: Res<GlobalRngSeed<ChaCha8Rng>>) {
+    assert_eq!(seed.get_seed(), [2; 32]);
+}
+
 /// Entities having their own sources side-steps issues with parallel execution and scheduling
 /// not ensuring that certain systems run before others. With an entity having its own RNG source,
 /// no matter when the systems that query that entity run, it will always result in a deterministic
@@ -114,6 +118,7 @@ fn test_parallel_determinism() {
                 random_output_c,
                 random_output_d,
                 random_output_e,
+                read_global_seed,
             ),
         )
         .run();

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -107,8 +107,17 @@ fn read_global_seed(seed: Res<GlobalRngSeed<ChaCha8Rng>>) {
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_parallel_determinism() {
-    App::new()
-        .add_plugins(EntropyPlugin::<ChaCha8Rng>::with_seed([2; 32]))
+    let mut app = App::new();
+
+    #[cfg(not(target_arch = "wasm32"))]
+    app.edit_schedule(Update, |schedule| {
+        use bevy::ecs::schedule::ExecutorKind;
+
+        // Ensure the Update schedule is Multithreaded on non-WASM platforms
+        schedule.set_executor_kind(ExecutorKind::MultiThreaded);
+    });
+
+    app.add_plugins(EntropyPlugin::<ChaCha8Rng>::with_seed([2; 32]))
         .add_systems(Startup, setup_sources)
         .add_systems(
             Update,


### PR DESCRIPTION
Adds a `GlobalRngSeed` resource with reflection support, mainly for allowing users to track/monitor the initial starting seed/state for a given `GlobalEntropy`. This should allow for users to also write systems that can force a `GlobalEntropy` resource to reseed.

Closes #18 