### PR TITLE
feat: RngSeed & ForkableSeed traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/Bluefinger/bevy_rand"
 license = "MIT OR Apache-2.0"
-version = "0.7.1"
+version = "0.8.0"
 rust-version = "1.76.0"
 
 [workspace.dependencies]
@@ -45,7 +45,7 @@ wyrand = ["bevy_prng/wyrand"]
 [dependencies]
 # bevy
 bevy.workspace = true
-bevy_prng = { path = "bevy_prng", version = "0.7" }
+bevy_prng = { path = "bevy_prng", version = "0.8" }
 
 # others
 getrandom = "0.2"
@@ -59,10 +59,10 @@ serde_derive = { workspace = true, optional = true }
 # cannot be out of step with bevy_rand due to dependencies on traits
 # and implementations between the two crates.
 [target.'cfg(any())'.dependencies]
-bevy_prng = { path = "bevy_prng", version = "=0.7" }
+bevy_prng = { path = "bevy_prng", version = "=0.8" }
 
 [dev-dependencies]
-bevy_prng = { path = "bevy_prng", version = "0.7", features = ["rand_chacha", "wyrand"] }
+bevy_prng = { path = "bevy_prng", version = "0.8", features = ["rand_chacha", "wyrand"] }
 rand = "0.8"
 ron = { version = "0.8.0", features = ["integer128"] }
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -23,3 +23,7 @@ This **will** change the type path and the serialization format for the PRNGs, b
 ## Migrating from v0.5 to v0.6
 
 As the `wyrand` dependency has been updated and contains a breaking output change, users of `bevy_rand` making use of the `wyrand` feature will need to update their code in cases where deterministic output from the old version is expected. The new `WyRand` output is considered to provide better entropy than the old version, so it is recommended to adopt the new version. In reality, this is likely to affect tests and serialised output rather than game code.
+
+## Migrating from v0.7 to v0.8
+
+`GlobalRngSeed` has been changed to make use of `SeedSource` trait, for things like instantiation: `new` is now `from_seed`. `get_seed` is now `clone_seed`. Most of these changes can be done easily by importing the `SeedSource` trait.

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ All supported PRNGs and compatible structs are provided by the `bevy_prng` crate
 #### `bevy_rand` feature activation
 ```toml
 rand_core = "0.6"
-bevy_rand = { version = "0.7", features = ["rand_chacha", "wyrand"] }
+bevy_rand = { version = "0.8", features = ["rand_chacha", "wyrand"] }
 ```
 
 #### `bevy_prng` feature activation
 ```toml
 rand_core = "0.6"
-bevy_rand = "0.7"
-bevy_prng = { version = "0.7", features = ["rand_chacha", "wyrand"] }
+bevy_rand = "0.8"
+bevy_prng = { version = "0.8", features = ["rand_chacha", "wyrand"] }
 ```
 
 The summary of what RNG algorithm to choose is: pick `wyrand` for almost all cases as it is faster and more portable than other algorithms. For cases where you need the extra assurance of entropy quality (for security, etc), then use `rand_chacha`. For more information, [go here](https://docs.rs/bevy_rand/latest/bevy_rand/tutorial/ch01_choosing_prng/index.html).
@@ -128,7 +128,7 @@ fn setup_npc_from_source(
 
 | `bevy` | `bevy_rand`  |
 | ------ | ------------ |
-| v0.14  | v0.7         |
+| v0.14  | v0.7 - v0.8  |
 | v0.13  | v0.5 - v0.6  |
 | v0.12  | v0.4         |
 | v0.11  | v0.2 - v0.3  |
@@ -138,7 +138,7 @@ The versions of `rand_core`/`rand` that `bevy_rand` is compatible with is as fol
 
 | `bevy_rand`  | `rand_core` | `rand` |
 | ------------ | ----------- | ------ |
-| v0.1 -> v0.7 | v0.6        | v0.8   |
+| v0.1 -> v0.8 | v0.6        | v0.8   |
 
 ## Migrations
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, allow(unused_attributes))]
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
 /// Components for integrating [`RngCore`] PRNGs into bevy. Must be newtyped to support [`Reflect`].

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,4 +1,9 @@
-use crate::{component::EntropyComponent, resource::GlobalEntropy, seed::GlobalRngSeed};
+use crate::{
+    component::EntropyComponent,
+    resource::GlobalEntropy,
+    seed::{GlobalRngSeed, RngSeed},
+    traits::SeedSource,
+};
 use bevy::{
     prelude::{App, Plugin},
     reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath},
@@ -68,16 +73,18 @@ where
 {
     fn build(&self, app: &mut App) {
         app.register_type::<GlobalEntropy<R>>()
-            .register_type::<EntropyComponent<R>>();
-
-        GlobalRngSeed::<R>::register_type(app);
+            .register_type::<EntropyComponent<R>>()
+            .register_type::<GlobalRngSeed<R>>()
+            .register_type::<R::Seed>();
 
         if let Some(seed) = self.seed.as_ref() {
-            app.insert_resource(GlobalRngSeed::<R>::new(seed.clone()));
+            app.insert_resource(GlobalRngSeed::<R>::from_seed(seed.clone()));
         } else {
             app.init_resource::<GlobalRngSeed<R>>();
         }
 
-        app.init_resource::<GlobalEntropy<R>>();
+        app.init_resource::<GlobalEntropy<R>>()
+            .world_mut()
+            .register_component_hooks::<RngSeed<R>>();
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,9 @@ pub use crate::component::EntropyComponent;
 pub use crate::plugin::EntropyPlugin;
 pub use crate::resource::GlobalEntropy;
 pub use crate::seed::GlobalRngSeed;
-pub use crate::traits::{ForkableAsRng, ForkableInnerRng, ForkableRng};
+pub use crate::traits::{
+    ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng, ForkableSeed,
+};
 #[cfg(feature = "wyrand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
 pub use bevy_prng::WyRand;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,9 +1,9 @@
 pub use crate::component::EntropyComponent;
 pub use crate::plugin::EntropyPlugin;
 pub use crate::resource::GlobalEntropy;
-pub use crate::seed::GlobalRngSeed;
+pub use crate::seed::{GlobalRngSeed, RngSeed};
 pub use crate::traits::{
-    ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng, ForkableSeed,
+    ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng, ForkableSeed, SeedSource
 };
 #[cfg(feature = "wyrand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -2,8 +2,11 @@ use std::fmt::Debug;
 
 use crate::{
     component::EntropyComponent,
-    seed::GlobalRngSeed,
-    traits::{EcsEntropySource, ForkableAsRng, ForkableInnerRng, ForkableRng},
+    seed::{GlobalRngSeed, RngSeed},
+    traits::{
+        EcsEntropySource, ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng,
+        ForkableSeed,
+    },
 };
 use bevy::{
     ecs::world::{FromWorld, World},
@@ -125,6 +128,11 @@ impl<R: SeedableEntropySource + 'static> SeedableRng for GlobalEntropy<R> {
         Self::new(R::from_seed(seed))
     }
 
+    #[inline]
+    fn from_rng<S: RngCore>(rng: S) -> Result<Self, rand_core::Error> {
+        R::from_rng(rng).map(Self::new)
+    }
+
     /// Creates a new instance of the RNG seeded via [`ThreadLocalEntropy`]. This method is the recommended way
     /// to construct non-deterministic PRNGs since it is convenient and secure. It overrides the standard
     /// [`SeedableRng::from_entropy`] method while the `thread_local_entropy` feature is enabled.
@@ -136,14 +144,8 @@ impl<R: SeedableEntropySource + 'static> SeedableRng for GlobalEntropy<R> {
     #[cfg(feature = "thread_local_entropy")]
     #[cfg_attr(docsrs, doc(cfg(feature = "thread_local_entropy")))]
     fn from_entropy() -> Self {
-        let mut seed = Self::Seed::default();
-
-        // Source entropy from thread local user-space RNG instead of
-        // system entropy source to reduce overhead when creating many
-        // rng instances for many resources at once.
-        ThreadLocalEntropy::new().fill_bytes(seed.as_mut());
-
-        Self::from_seed(seed)
+        // This operation should never yield Err on any supported PRNGs
+        Self::from_rng(ThreadLocalEntropy::new()).unwrap()
     }
 }
 
@@ -180,6 +182,21 @@ where
     R: SeedableEntropySource + 'static,
 {
     type Output = R;
+}
+
+impl<R> ForkableSeed<R> for GlobalEntropy<R>
+where
+    R: SeedableEntropySource + 'static,
+    R::Seed: Send + Sync + Clone,
+{
+    type Output = RngSeed<R>;
+}
+
+impl<R> ForkableAsSeed<R> for GlobalEntropy<R>
+where
+    R: SeedableEntropySource + 'static,
+{
+    type Output<T> = RngSeed<T> where T: SeedableEntropySource, T::Seed: Send + Sync + Clone;
 }
 
 #[cfg(test)]
@@ -246,7 +263,7 @@ mod tests {
     #[test]
     fn rng_untyped_serialization() {
         use bevy::reflect::{
-            serde::{ReflectSerializer, ReflectDeserializer},
+            serde::{ReflectDeserializer, ReflectSerializer},
             TypeRegistry,
         };
         use ron::ser::to_string;

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -5,7 +5,7 @@ use crate::{
     seed::{GlobalRngSeed, RngSeed},
     traits::{
         EcsEntropySource, ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng,
-        ForkableSeed,
+        ForkableSeed, SeedSource,
     },
 };
 use bevy::{
@@ -91,7 +91,7 @@ where
 {
     fn from_world(world: &mut World) -> Self {
         if let Some(seed) = world.get_resource::<GlobalRngSeed<R>>() {
-            Self::new(R::from_seed(seed.get_seed()))
+            Self::new(R::from_seed(seed.clone_seed()))
         } else {
             Self::from_entropy()
         }

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -35,7 +35,7 @@ impl<R: SeedableEntropySource> SeedSource<R> for GlobalRngSeed<R>
 where
     R::Seed: Sync + Send + Clone,
 {
-    /// Create a new instance of [`GlobalRngSeed`].
+    /// Create a new instance of [`GlobalRngSeed`] from a given `seed` value.
     #[inline]
     #[must_use]
     fn from_seed(seed: R::Seed) -> Self {
@@ -43,6 +43,16 @@ where
             seed,
             rng: PhantomData,
         }
+    }
+
+    #[inline]
+    fn get_seed(&self) -> &R::Seed {
+        &self.seed
+    }
+
+    #[inline]
+    fn clone_seed(&self) -> R::Seed {
+        self.seed.clone()
     }
 }
 
@@ -63,12 +73,6 @@ impl<R: SeedableEntropySource> GlobalRngSeed<R>
 where
     R::Seed: Sync + Send + Clone,
 {
-    /// Returns a cloned instance of the seed value.
-    #[inline]
-    pub fn get_seed(&self) -> R::Seed {
-        self.seed.clone()
-    }
-
     /// Set the global seed to a new value
     pub fn set_seed(&mut self, seed: R::Seed) {
         self.seed = seed;
@@ -110,11 +114,24 @@ impl<R: SeedableEntropySource> SeedSource<R> for RngSeed<R>
 where
     R::Seed: Sync + Send + Clone,
 {
+    /// Create a new instance of [`RngSeed`] from a given `seed` value.
+    #[inline]
+    #[must_use]
     fn from_seed(seed: R::Seed) -> Self {
         Self {
             seed,
             rng: PhantomData,
         }
+    }
+
+    #[inline]
+    fn get_seed(&self) -> &R::Seed {
+        &self.seed
+    }
+
+    #[inline]
+    fn clone_seed(&self) -> R::Seed {
+        self.seed.clone()
     }
 }
 
@@ -183,6 +200,6 @@ mod tests {
 
         let recreated = GlobalRngSeed::<WyRand>::from_reflect(value.as_reflect()).unwrap();
 
-        assert_eq!(val.get_seed(), recreated.get_seed());
+        assert_eq!(val.clone_seed(), recreated.clone_seed());
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -96,12 +96,138 @@ pub trait ForkableInnerRng: EcsEntropySource {
     }
 }
 
+/// Trait for implementing forking behaviour for [`crate::component::EntropyComponent`] and [`crate::resource::GlobalEntropy`].
+/// Forking creates a new RNG instance using a generated seed from the original source. If the original is seeded with a known
+/// seed, this process is deterministic. This trait enables forking from an entropy source to a seed component.
+pub trait ForkableSeed<S: SeedableEntropySource>: EcsEntropySource
+where
+    S::Seed: Send + Sync + Clone,
+{
+    /// The type of seed component that is to be forked from the original source.
+    type Output: SeedSource<S>;
+
+    /// Fork a new seed from the original entropy source.
+    /// This method preserves the RNG algorithm between original instance and forked seed.
+    /// ```
+    /// use bevy::prelude::*;
+    /// use bevy_prng::ChaCha8Rng;
+    /// use bevy_rand::prelude::{GlobalEntropy, ForkableSeed};
+    ///
+    /// #[derive(Component)]
+    /// struct Source;
+    ///
+    /// fn setup_source(mut commands: Commands, mut global: ResMut<GlobalEntropy<ChaCha8Rng>>) {
+    ///     commands
+    ///         .spawn((
+    ///             Source,
+    ///             global.fork_seed(),
+    ///         ));
+    /// }
+    /// ```
+    fn fork_seed(&mut self) -> Self::Output {
+        let mut seed = S::Seed::default();
+
+        self.fill_bytes(seed.as_mut());
+
+        Self::Output::from_seed(seed)
+    }
+}
+
+/// Trait for implementing Forking behaviour for [`crate::component::EntropyComponent`] and [`crate::resource::GlobalEntropy`].
+/// Forking creates a new RNG instance using a generated seed from the original source. If the original is seeded with a known
+/// seed, this process is deterministic. This trait enables forking from an entropy source to a seed component of a different
+/// PRNG algorithm.
+pub trait ForkableAsSeed<S: SeedableEntropySource>: EcsEntropySource {
+    /// The type of seed component that is to be forked from the original source.
+    type Output<T>: SeedSource<T>
+    where
+        T: SeedableEntropySource,
+        T::Seed: Send + Sync + Clone;
+
+    /// Fork a new seed from the original entropy source.
+    /// This method allows one to specify the RNG algorithm to be used for the forked seed.
+    /// ```
+    /// use bevy::prelude::*;
+    /// use bevy_rand::prelude::{GlobalEntropy, ForkableAsSeed};
+    /// use bevy_prng::{ChaCha8Rng, ChaCha12Rng};
+    ///
+    /// #[derive(Component)]
+    /// struct Source;
+    ///
+    /// fn setup_source(mut commands: Commands, mut global: ResMut<GlobalEntropy<ChaCha12Rng>>) {
+    ///     commands
+    ///         .spawn((
+    ///             Source,
+    ///             global.fork_as_seed::<ChaCha8Rng>(),
+    ///         ));
+    /// }
+    /// ```
+    fn fork_as_seed<T: SeedableEntropySource>(&mut self) -> Self::Output<T>
+    where
+        T::Seed: Send + Sync + Clone,
+    {
+        let mut seed = T::Seed::default();
+
+        self.fill_bytes(seed.as_mut());
+
+        Self::Output::<T>::from_seed(seed)
+    }
+}
+
+/// A trait for providing [`crate::seed::GlobalRngSeed`] and [`crate::seed::RngSeed`] with
+/// common initialization strategies. This trait is not object safe and is also a sealed trait.
+pub trait SeedSource<R: SeedableEntropySource>: private::SealedSeed<R>
+where
+    R::Seed: Send + Sync + Clone,
+{
+    /// Initialize a [`SeedSource`] from a given `seed` value.
+    fn from_seed(seed: R::Seed) -> Self;
+
+    /// Initialize a [`SeedSource`] from a `seed` value obtained from a
+    /// OS-level or user-space RNG source.
+    fn from_entropy() -> Self
+    where
+        Self: Sized,
+    {
+        let mut dest = R::Seed::default();
+
+        #[cfg(feature = "thread_local_entropy")]
+        {
+            use crate::thread_local_entropy::ThreadLocalEntropy;
+
+            ThreadLocalEntropy::new().fill_bytes(dest.as_mut());
+        }
+        #[cfg(not(feature = "thread_local_entropy"))]
+        {
+            use getrandom::getrandom;
+
+            getrandom(seed.as_mut()).expect("Unable to source entropy for seeding");
+        }
+
+        Self::from_seed(dest)
+    }
+}
+
 /// A marker trait for [`crate::component::EntropyComponent`] and [`crate::resource::GlobalEntropy`].
 /// This is a sealed trait and cannot be consumed by downstream.
 pub trait EcsEntropySource: RngCore + SeedableRng + private::SealedSource {}
 
 mod private {
-    pub trait SealedSource {}
+    use super::{EcsEntropySource, SeedSource, SeedableEntropySource};
 
-    impl<T: super::EcsEntropySource> SealedSource for T {}
+    pub trait SealedSource {}
+    pub trait SealedSeed<R>
+    where
+        R: SeedableEntropySource,
+    {
+    }
+
+    impl<T> SealedSource for T where T: EcsEntropySource {}
+    impl<R, T> SealedSeed<R> for T
+    where
+        T: SeedSource<R>,
+        R: SeedableEntropySource,
+        R::Seed: Send + Sync + Clone,
+    {
+    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -183,6 +183,12 @@ where
     /// Initialize a [`SeedSource`] from a given `seed` value.
     fn from_seed(seed: R::Seed) -> Self;
 
+    /// Returns a reference of the seed value.
+    fn get_seed(&self) -> &R::Seed;
+
+    /// Returns a cloned instance of the seed value.
+    fn clone_seed(&self) -> R::Seed;
+
     /// Initialize a [`SeedSource`] from a `seed` value obtained from a
     /// OS-level or user-space RNG source.
     fn from_entropy() -> Self

--- a/tests/integration/determinism.rs
+++ b/tests/integration/determinism.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_prng::{ChaCha12Rng, ChaCha8Rng, WyRand};
 use bevy_rand::prelude::{
-    EntropyComponent, EntropyPlugin, ForkableAsRng, ForkableRng, GlobalEntropy, GlobalRngSeed,
+    EntropyComponent, EntropyPlugin, ForkableAsRng, ForkableRng, GlobalEntropy, GlobalRngSeed, SeedSource
 };
 use rand::prelude::Rng;
 
@@ -88,7 +88,7 @@ fn setup_sources(mut commands: Commands, mut rng: ResMut<GlobalEntropy<ChaCha8Rn
 }
 
 fn read_global_seed(seed: Res<GlobalRngSeed<ChaCha8Rng>>) {
-    assert_eq!(seed.get_seed(), [2; 32]);
+    assert_eq!(seed.get_seed(), &[2; 32]);
 }
 
 /// Entities having their own sources side-steps issues with parallel execution and scheduling

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,0 +1,2 @@
+pub mod determinism;
+pub mod reseeding;

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -8,7 +8,7 @@ use bevy_rand::{
     prelude::EntropyComponent,
     resource::GlobalEntropy,
     seed::GlobalRngSeed,
-    traits::{ForkableAsSeed, ForkableSeed},
+    traits::{ForkableAsSeed, ForkableSeed, SeedSource},
 };
 use rand_core::{RngCore, SeedableRng};
 
@@ -26,7 +26,7 @@ fn test_global_reseeding() {
         R::Seed: Sync + Send + Clone,
     {
         if seed.is_changed() && !seed.is_added() {
-            rng.reseed(seed.get_seed());
+            rng.reseed(seed.clone_seed());
         }
     }
 

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -1,0 +1,152 @@
+use bevy::{
+    app::{App, PreStartup, PreUpdate, Update},
+    prelude::{Commands, DetectChanges, Query, Res, ResMut},
+};
+use bevy_prng::{ChaCha8Rng, SeedableEntropySource, WyRand};
+use bevy_rand::{
+    plugin::EntropyPlugin,
+    prelude::EntropyComponent,
+    resource::GlobalEntropy,
+    seed::GlobalRngSeed,
+    traits::{ForkableAsSeed, ForkableSeed},
+};
+use rand_core::{RngCore, SeedableRng};
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::*;
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_global_reseeding() {
+    /// Basic Reseeding mechanism by change detection against GlobalRngSeed
+    fn reseed_global_rng<R: SeedableEntropySource>(
+        seed: Res<GlobalRngSeed<R>>,
+        mut rng: ResMut<GlobalEntropy<R>>,
+    ) where
+        R::Seed: Sync + Send + Clone,
+    {
+        if seed.is_changed() && !seed.is_added() {
+            rng.reseed(seed.get_seed());
+        }
+    }
+
+    let mut app = App::new();
+
+    let seed = [2; 32];
+
+    let rng_eq = GlobalEntropy::<ChaCha8Rng>::from_seed(seed);
+
+    app.add_plugins(EntropyPlugin::<ChaCha8Rng>::with_seed(seed))
+        .add_systems(PreUpdate, reseed_global_rng::<ChaCha8Rng>);
+
+    {
+        let global_rng = app.world().resource_ref::<GlobalEntropy<ChaCha8Rng>>();
+        let global_seed = app.world().resource_ref::<GlobalRngSeed<ChaCha8Rng>>();
+
+        // Our RNGs should be the same as each other as they were initialised with the same seed
+        assert_eq!(global_rng.as_ref(), &rng_eq);
+
+        // The condition here should mean our reseeding system will NOT run
+        assert!(global_seed.is_changed() && global_seed.is_added());
+    }
+
+    app.update();
+
+    {
+        let global_rng = app.world().resource_ref::<GlobalEntropy<ChaCha8Rng>>();
+
+        // Our RNGs should remain the same as each other as we have not run the update
+        assert_eq!(global_rng.as_ref(), &rng_eq);
+    }
+
+    {
+        let mut global_seed = app.world_mut().resource_mut::<GlobalRngSeed<ChaCha8Rng>>();
+
+        global_seed.set_seed([3; 32]);
+
+        // The condition here should mean our reseeding system WILL run
+        assert!(global_seed.is_changed() && !global_seed.is_added());
+    }
+
+    app.update();
+
+    {
+        let global_rng = app.world().resource_ref::<GlobalEntropy<ChaCha8Rng>>();
+
+        // Now our RNG will not be the same, even though we did not use it directly
+        assert_ne!(global_rng.as_ref(), &rng_eq);
+    }
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn component_fork_seed() {
+    let mut app = App::new();
+
+    let seed = [2; 32];
+
+    app.add_plugins(EntropyPlugin::<ChaCha8Rng>::with_seed(seed))
+        .add_systems(
+            PreStartup,
+            |mut commands: Commands, mut rng: ResMut<GlobalEntropy<ChaCha8Rng>>| {
+                for _ in 0..5 {
+                    commands.spawn(rng.fork_seed());
+                }
+            },
+        )
+        .add_systems(
+            Update,
+            |mut q_rng: Query<&mut EntropyComponent<ChaCha8Rng>>| {
+                let rngs = q_rng.iter_mut();
+
+                assert_eq!(rngs.size_hint().0, 5);
+
+                let values: Vec<_> = rngs.map(|mut rng| rng.next_u32()).collect();
+
+                assert_eq!(
+                    &values,
+                    &[3315785188, 1951699392, 911252207, 791343233, 1599472206]
+                );
+            },
+        );
+
+    app.update();
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn component_fork_as_seed() {
+    let mut app = App::new();
+
+    let seed = [2; 32];
+
+    app.add_plugins(EntropyPlugin::<ChaCha8Rng>::with_seed(seed))
+        .add_systems(
+            PreStartup,
+            |mut commands: Commands, mut rng: ResMut<GlobalEntropy<ChaCha8Rng>>| {
+                for _ in 0..5 {
+                    commands.spawn(rng.fork_as_seed::<WyRand>());
+                }
+            },
+        )
+        .add_systems(Update, |mut q_rng: Query<&mut EntropyComponent<WyRand>>| {
+            let rngs = q_rng.iter_mut();
+
+            assert_eq!(rngs.size_hint().0, 5);
+
+            let values: Vec<_> = rngs.map(|mut rng| rng.next_u64()).collect();
+
+            assert_eq!(
+                &values,
+                &[
+                    10032395693880520184,
+                    15375025802368380325,
+                    10863580644061233257,
+                    7067543572507795213,
+                    7996461288508244033
+                ]
+            );
+        });
+
+    app.update();
+}

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -1,0 +1,5 @@
+#![allow(clippy::type_complexity)]
+pub mod integration;
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);


### PR DESCRIPTION
This PR adds a `RngSeed` component type for containing the seed value of an `EntropyComponent`, plus establishing the relationship between the two components so that adding or overwriting a `RngSeed` component to an entity will add/overwrite an `EntropyComponent` of the same PRNG type. This is implemented using component hooks and will be automatically initialised when using the plugin to register entropy source types.

With this, I've also added extra forking traits to enable PRNG sources to fork to a seed component, whether of the same or different algorithm type.

I've also restructured the integration tests to build into a single test binary, but have separate modules for clarity purpose's sake. This should allow the integration test suite to grow considerably without needing to generate a separate binary for each integration test module.