### PR TITLE
refactor(GlobalRng): Merge seed resource with rng source

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -26,4 +26,4 @@ As the `wyrand` dependency has been updated and contains a breaking output chang
 
 ## Migrating from v0.7 to v0.8
 
-`GlobalRngSeed` has been removed, instead being rolled into `GlobalEntropy`. This will allow better reflection tracking of the global rng source, and will allow for automatic reseeding without any custom system needing to be provided. Use the `reseed` method to reinstantiate the internal RNG source with the new seed, and `get_seed` to return a reference to the initial starting seed for the source.
+`GlobalRngSeed` has been removed, instead being rolled into `GlobalEntropy`. This will allow better reflection tracking of the global rng source, and will allow for automatic reseeding without any custom system needing to be provided. Use the `reseed` method to reinstantiate the internal RNG source with the new seed, and `get_seed` to return a reference to the initial starting seed for the source. The serialized format of `GlobalEntropy` has changed and previously serialized instances are no longer compatible.

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -26,4 +26,4 @@ As the `wyrand` dependency has been updated and contains a breaking output chang
 
 ## Migrating from v0.7 to v0.8
 
-`GlobalRngSeed` has been changed to make use of `SeedSource` trait, for things like instantiation: `new` is now `from_seed`. `get_seed` is now `clone_seed`. Most of these changes can be done easily by importing the `SeedSource` trait.
+`GlobalRngSeed` has been removed, instead being rolled into `GlobalEntropy`. This will allow better reflection tracking of the global rng source, and will allow for automatic reseeding without any custom system needing to be provided. Use the `reseed` method to reinstantiate the internal RNG source with the new seed, and `get_seed` to return a reference to the initial starting seed for the source.

--- a/bevy_prng/src/lib.rs
+++ b/bevy_prng/src/lib.rs
@@ -62,6 +62,43 @@ pub trait SeedableEntropySource:
 {
 }
 
+/// Marker trait for a suitable seed for [`SeedableEntropySource`]. This is an auto trait which will 
+/// apply to all suitable types that meet the trait criteria.
+#[cfg(feature = "serialize")]
+pub trait EntropySeed:
+    Debug
+    + Default
+    + PartialEq
+    + Clone
+    + Sync
+    + Send
+    + Reflect
+    + TypePath
+    + FromReflect
+    + GetTypeRegistration
+    + Serialize
+    + for<'a> Deserialize<'a>
+{
+}
+
+#[cfg(feature = "serialize")]
+impl<
+        T: Debug
+            + Default
+            + PartialEq
+            + Clone
+            + Sync
+            + Send
+            + Reflect
+            + TypePath
+            + FromReflect
+            + GetTypeRegistration
+            + Serialize
+            + for<'a> Deserialize<'a>,
+    > EntropySeed for T
+{
+}
+
 /// A marker trait to define the required trait bounds for a seedable PRNG to
 /// integrate into `EntropyComponent` or `GlobalEntropy`. This is a sealed trait.
 #[cfg(not(feature = "serialize"))]
@@ -78,6 +115,40 @@ pub trait SeedableEntropySource:
     + Sync
     + Send
     + private::SealedSeedable
+{
+}
+
+#[cfg(not(feature = "serialize"))]
+/// Marker trait for a suitable seed for [`SeedableEntropySource`]. This is an auto trait which will 
+/// apply to all suitable types that meet the trait criteria.
+pub trait EntropySeed:
+    Debug
+    + Default
+    + AsMut<u8>
+    + PartialEq
+    + Clone
+    + Sync
+    + Send
+    + Reflect
+    + TypePath
+    + FromReflect
+    + GetTypeRegistration //+ private::SealedSeed
+{
+}
+
+#[cfg(not(feature = "serialize"))]
+impl<
+        T: Debug
+            + Default
+            + PartialEq
+            + Clone
+            + Sync
+            + Send
+            + Reflect
+            + TypePath
+            + FromReflect
+            + GetTypeRegistration,
+    > EntropySeed for T
 {
 }
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -128,6 +128,7 @@ impl<R: SeedableEntropySource + 'static> EntropyComponent<R> {
 }
 
 impl<R: SeedableEntropySource + 'static> Default for EntropyComponent<R> {
+    #[inline]
     fn default() -> Self {
         Self::from_entropy()
     }

--- a/src/component.rs
+++ b/src/component.rs
@@ -1,14 +1,13 @@
 use std::fmt::Debug;
 
 use crate::{
-    resource::GlobalEntropy,
     seed::RngSeed,
     traits::{
         EcsEntropySource, ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng,
         ForkableSeed,
     },
 };
-use bevy::prelude::{Component, Mut, Reflect, ReflectComponent, ReflectFromReflect, ResMut};
+use bevy::prelude::{Component, Reflect, ReflectComponent, ReflectFromReflect};
 use bevy_prng::SeedableEntropySource;
 use rand_core::{RngCore, SeedableRng};
 
@@ -186,34 +185,6 @@ impl<R: SeedableEntropySource + 'static> SeedableRng for EntropyComponent<R> {
 }
 
 impl<R: SeedableEntropySource + 'static> EcsEntropySource for EntropyComponent<R> {}
-
-impl<R: SeedableEntropySource + 'static> From<R> for EntropyComponent<R> {
-    fn from(value: R) -> Self {
-        Self::new(value)
-    }
-}
-
-impl<R: SeedableEntropySource + 'static> From<&mut EntropyComponent<R>> for EntropyComponent<R> {
-    fn from(rng: &mut EntropyComponent<R>) -> Self {
-        Self::from_rng(rng).unwrap()
-    }
-}
-
-impl<R: SeedableEntropySource + 'static> From<&mut Mut<'_, EntropyComponent<R>>>
-    for EntropyComponent<R>
-{
-    fn from(rng: &mut Mut<'_, EntropyComponent<R>>) -> Self {
-        Self::from(rng.as_mut())
-    }
-}
-
-impl<R: SeedableEntropySource + 'static> From<&mut ResMut<'_, GlobalEntropy<R>>>
-    for EntropyComponent<R>
-{
-    fn from(rng: &mut ResMut<'_, GlobalEntropy<R>>) -> Self {
-        Self::from_rng(rng.as_mut()).unwrap()
-    }
-}
 
 impl<R> ForkableRng for EntropyComponent<R>
 where

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,14 +1,7 @@
-use crate::{
-    component::EntropyComponent,
-    resource::GlobalEntropy,
-    seed::{GlobalRngSeed, RngSeed},
-    traits::SeedSource,
-};
-use bevy::{
-    prelude::{App, Plugin},
-    reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath},
-};
-use bevy_prng::SeedableEntropySource;
+use crate::{component::EntropyComponent, resource::GlobalEntropy, seed::RngSeed};
+use bevy::prelude::{App, Plugin};
+use bevy_prng::{EntropySeed, SeedableEntropySource};
+use rand_core::SeedableRng;
 
 /// Plugin for integrating a PRNG that implements `RngCore` into
 /// the bevy engine, registering types for a global resource and
@@ -69,22 +62,19 @@ where
 
 impl<R: SeedableEntropySource + 'static> Plugin for EntropyPlugin<R>
 where
-    R::Seed: Send + Sync + Clone + Reflect + FromReflect + GetTypeRegistration + TypePath,
+    R::Seed: EntropySeed,
 {
     fn build(&self, app: &mut App) {
         app.register_type::<GlobalEntropy<R>>()
             .register_type::<EntropyComponent<R>>()
-            .register_type::<GlobalRngSeed<R>>()
             .register_type::<R::Seed>();
 
         if let Some(seed) = self.seed.as_ref() {
-            app.insert_resource(GlobalRngSeed::<R>::from_seed(seed.clone()));
+            app.insert_resource(GlobalEntropy::<R>::from_seed(seed.clone()));
         } else {
-            app.init_resource::<GlobalRngSeed<R>>();
+            app.init_resource::<GlobalEntropy<R>>();
         }
 
-        app.init_resource::<GlobalEntropy<R>>()
-            .world_mut()
-            .register_component_hooks::<RngSeed<R>>();
+        app.world_mut().register_component_hooks::<RngSeed<R>>();
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,9 +1,9 @@
 pub use crate::component::EntropyComponent;
 pub use crate::plugin::EntropyPlugin;
 pub use crate::resource::GlobalEntropy;
-pub use crate::seed::{GlobalRngSeed, RngSeed};
+pub use crate::seed::RngSeed;
 pub use crate::traits::{
-    ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng, ForkableSeed, SeedSource
+    ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng, ForkableSeed, SeedSource,
 };
 #[cfg(feature = "wyrand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -2,16 +2,13 @@ use std::fmt::Debug;
 
 use crate::{
     component::EntropyComponent,
-    seed::{GlobalRngSeed, RngSeed},
+    seed::RngSeed,
     traits::{
         EcsEntropySource, ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng,
-        ForkableSeed, SeedSource,
+        ForkableSeed,
     },
 };
-use bevy::{
-    ecs::world::{FromWorld, World},
-    prelude::{Reflect, ReflectFromReflect, ReflectFromWorld, ReflectResource, Resource},
-};
+use bevy::prelude::{Reflect, ReflectFromReflect, ReflectFromWorld, ReflectResource, Resource};
 use bevy_prng::SeedableEntropySource;
 use rand_core::{RngCore, SeedableRng};
 
@@ -22,7 +19,7 @@ use crate::thread_local_entropy::ThreadLocalEntropy;
 use bevy::prelude::{ReflectDeserialize, ReflectSerialize};
 
 #[cfg(feature = "serialize")]
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A Global [`RngCore`] instance, meant for use as a Resource. Gets
 /// created automatically with [`crate::plugin::EntropyPlugin`], or
@@ -43,14 +40,6 @@ use serde::Deserialize;
 #[derive(Debug, Clone, PartialEq, Eq, Resource, Reflect)]
 #[cfg_attr(
     feature = "serialize",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
-#[cfg_attr(
-    feature = "serialize",
-    serde(bound(deserialize = "R: for<'a> Deserialize<'a>"))
-)]
-#[cfg_attr(
-    feature = "serialize",
     reflect(
         Debug,
         PartialEq,
@@ -65,72 +54,83 @@ use serde::Deserialize;
     not(feature = "serialize"),
     reflect(Debug, PartialEq, Resource, FromReflect, FromWorld)
 )]
-#[reflect(where R::Seed: Sync + Send + Clone)]
-pub struct GlobalEntropy<R: SeedableEntropySource + 'static>(R);
-
-impl<R: SeedableEntropySource + 'static> GlobalEntropy<R> {
-    /// Create a new resource from a `RngCore` instance.
-    #[inline]
-    #[must_use]
-    pub fn new(rng: R) -> Self {
-        Self(rng)
-    }
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
+#[cfg_attr(
+    feature = "serialize",
+    serde(bound(deserialize = "R: for<'a> Deserialize<'a>, R::Seed: for<'a> Deserialize<'a>"))
+)]
+#[cfg_attr(feature = "serialize", reflect(where R::Seed: PartialEq + Debug + Sync + Send + Clone + Serialize + for<'a> Deserialize<'a>))]
+#[cfg_attr(not(feature = "serialize"), reflect(where R::Seed: PartialEq + Debug + Sync + Send + Clone))]
+pub struct GlobalEntropy<R: SeedableEntropySource + 'static> {
+    seed: R::Seed,
+    rng: R,
 }
 
-impl<R: SeedableEntropySource + 'static> GlobalEntropy<R> {
+impl<R: SeedableEntropySource + 'static> GlobalEntropy<R>
+where
+    R::Seed: Clone,
+{
+    #[inline]
+    #[must_use]
+    fn new(seed: R::Seed) -> Self {
+        Self {
+            seed: seed.clone(),
+            rng: R::from_seed(seed),
+        }
+    }
+
     /// Reseeds the internal `RngCore` instance with a new seed.
     #[inline]
     pub fn reseed(&mut self, seed: R::Seed) {
-        self.0 = R::from_seed(seed);
+        self.seed = seed.clone();
+        self.rng = R::from_seed(seed);
+    }
+
+    /// Get a reference to the initial seed
+    pub fn get_seed(&self) -> &R::Seed {
+        &self.seed
     }
 }
 
-impl<R: SeedableEntropySource + 'static> FromWorld for GlobalEntropy<R>
+impl<R: SeedableEntropySource + 'static> Default for GlobalEntropy<R>
 where
-    R::Seed: Send + Sync + Clone,
+    R::Seed: Clone,
 {
-    fn from_world(world: &mut World) -> Self {
-        if let Some(seed) = world.get_resource::<GlobalRngSeed<R>>() {
-            Self::new(R::from_seed(seed.clone_seed()))
-        } else {
-            Self::from_entropy()
-        }
+    fn default() -> Self {
+        Self::from_entropy()
     }
 }
 
 impl<R: SeedableEntropySource + 'static> RngCore for GlobalEntropy<R> {
-    #[inline]
     fn next_u32(&mut self) -> u32 {
-        self.0.next_u32()
+        self.rng.next_u32()
     }
 
-    #[inline]
     fn next_u64(&mut self) -> u64 {
-        self.0.next_u64()
+        self.rng.next_u64()
     }
 
-    #[inline]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.0.fill_bytes(dest);
+        self.rng.fill_bytes(dest);
     }
 
-    #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.0.try_fill_bytes(dest)
+        self.rng.try_fill_bytes(dest)
     }
 }
 
-impl<R: SeedableEntropySource + 'static> SeedableRng for GlobalEntropy<R> {
+impl<R: SeedableEntropySource + 'static> SeedableRng for GlobalEntropy<R>
+where
+    R::Seed: Clone,
+{
     type Seed = R::Seed;
 
     #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
-        Self::new(R::from_seed(seed))
-    }
-
-    #[inline]
-    fn from_rng<S: RngCore>(rng: S) -> Result<Self, rand_core::Error> {
-        R::from_rng(rng).map(Self::new)
+        Self::new(seed)
     }
 
     /// Creates a new instance of the RNG seeded via [`ThreadLocalEntropy`]. This method is the recommended way
@@ -144,28 +144,20 @@ impl<R: SeedableEntropySource + 'static> SeedableRng for GlobalEntropy<R> {
     #[cfg(feature = "thread_local_entropy")]
     #[cfg_attr(docsrs, doc(cfg(feature = "thread_local_entropy")))]
     fn from_entropy() -> Self {
-        // This operation should never yield Err on any supported PRNGs
-        Self::from_rng(ThreadLocalEntropy::new()).unwrap()
+        let mut seed = R::Seed::default();
+
+        ThreadLocalEntropy::new().fill_bytes(seed.as_mut());
+
+        Self::new(seed)
     }
 }
 
-impl<R: SeedableEntropySource + 'static> EcsEntropySource for GlobalEntropy<R> {}
-
-impl<R: SeedableEntropySource + 'static> From<R> for GlobalEntropy<R> {
-    fn from(value: R) -> Self {
-        Self::new(value)
-    }
-}
-
-impl<R: SeedableEntropySource + 'static> From<&mut R> for GlobalEntropy<R> {
-    fn from(value: &mut R) -> Self {
-        Self::from_rng(value).unwrap()
-    }
-}
+impl<R: SeedableEntropySource + 'static> EcsEntropySource for GlobalEntropy<R> where R::Seed: Clone {}
 
 impl<R> ForkableRng for GlobalEntropy<R>
 where
     R: SeedableEntropySource + 'static,
+    R::Seed: Clone,
 {
     type Output = EntropyComponent<R>;
 }
@@ -173,6 +165,7 @@ where
 impl<R> ForkableAsRng for GlobalEntropy<R>
 where
     R: SeedableEntropySource + 'static,
+    R::Seed: Clone,
 {
     type Output<T> = EntropyComponent<T> where T: SeedableEntropySource;
 }
@@ -180,6 +173,7 @@ where
 impl<R> ForkableInnerRng for GlobalEntropy<R>
 where
     R: SeedableEntropySource + 'static,
+    R::Seed: Clone,
 {
     type Output = R;
 }
@@ -195,6 +189,7 @@ where
 impl<R> ForkableAsSeed<R> for GlobalEntropy<R>
 where
     R: SeedableEntropySource + 'static,
+    R::Seed: Clone,
 {
     type Output<T> = RngSeed<T> where T: SeedableEntropySource, T::Seed: Send + Sync + Clone;
 }
@@ -254,7 +249,7 @@ mod tests {
         let rng2 = rng1.fork_inner();
 
         assert_ne!(
-            rng1.0, rng2,
+            rng1.rng, rng2,
             "forked ChaCha8Rngs should not match each other"
         );
     }
@@ -283,7 +278,7 @@ mod tests {
 
         assert_eq!(
             &serialized,
-            "{\"bevy_rand::resource::GlobalEntropy<bevy_prng::ChaCha8Rng>\":(((seed:(7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7),stream:0,word_pos:1)))}"
+            "{\"bevy_rand::resource::GlobalEntropy<bevy_prng::ChaCha8Rng>\":(seed:(7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7),rng:((seed:(7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7),stream:0,word_pos:1)))}"
         );
 
         let mut deserializer = ron::Deserializer::from_str(&serialized).unwrap();
@@ -333,7 +328,7 @@ mod tests {
 
         assert_eq!(
             &serialized,
-            "(((seed:(7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7),stream:0,word_pos:1)))"
+            "(seed:(7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7),rng:((seed:(7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7),stream:0,word_pos:1)))"
         );
 
         let mut deserializer = ron::Deserializer::from_str(&serialized).unwrap();

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -90,6 +90,7 @@ where
     }
 
     /// Get a reference to the initial seed
+    #[inline]
     pub fn get_seed(&self) -> &R::Seed {
         &self.seed
     }
@@ -99,24 +100,29 @@ impl<R: SeedableEntropySource + 'static> Default for GlobalEntropy<R>
 where
     R::Seed: Clone,
 {
+    #[inline]
     fn default() -> Self {
         Self::from_entropy()
     }
 }
 
 impl<R: SeedableEntropySource + 'static> RngCore for GlobalEntropy<R> {
+    #[inline]
     fn next_u32(&mut self) -> u32 {
         self.rng.next_u32()
     }
 
+    #[inline]
     fn next_u64(&mut self) -> u64 {
         self.rng.next_u64()
     }
 
+    #[inline]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.rng.fill_bytes(dest);
     }
 
+    #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
         self.rng.try_fill_bytes(dest)
     }

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,103 +1,10 @@
 use std::marker::PhantomData;
 
-use bevy::{
-    app::App,
-    ecs::{component::StorageType, system::Resource},
-    prelude::Component,
-    reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath},
-};
+use bevy::{ecs::component::StorageType, prelude::Component, reflect::Reflect};
 use bevy_prng::SeedableEntropySource;
 use rand_core::SeedableRng;
 
-#[cfg(feature = "serialize")]
-use serde::{Deserialize, Serialize};
-
 use crate::{component::EntropyComponent, traits::SeedSource};
-
-#[derive(Debug, Resource, Reflect)]
-#[cfg_attr(
-    feature = "serialize",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
-#[cfg_attr(
-    feature = "serialize",
-    serde(bound(deserialize = "R::Seed: Serialize + for<'a> Deserialize<'a>"))
-)]
-/// Resource for storing the initial seed used to initialize a [`crate::resource::GlobalEntropy`].
-/// Useful for tracking the starting seed or for forcing [`crate::resource::GlobalEntropy`] to reseed.
-pub struct GlobalRngSeed<R: SeedableEntropySource> {
-    seed: R::Seed,
-    #[reflect(ignore)]
-    rng: PhantomData<R>,
-}
-
-impl<R: SeedableEntropySource> SeedSource<R> for GlobalRngSeed<R>
-where
-    R::Seed: Sync + Send + Clone,
-{
-    /// Create a new instance of [`GlobalRngSeed`] from a given `seed` value.
-    #[inline]
-    #[must_use]
-    fn from_seed(seed: R::Seed) -> Self {
-        Self {
-            seed,
-            rng: PhantomData,
-        }
-    }
-
-    #[inline]
-    fn get_seed(&self) -> &R::Seed {
-        &self.seed
-    }
-
-    #[inline]
-    fn clone_seed(&self) -> R::Seed {
-        self.seed.clone()
-    }
-}
-
-impl<R: SeedableEntropySource> GlobalRngSeed<R>
-where
-    R::Seed: Sync + Send + Clone + Reflect + GetTypeRegistration + FromReflect + TypePath,
-{
-    /// Helper method to register the necessary types for [`Reflect`] purposes. Ensures
-    /// that not only the main type is registered, but also the correct seed type for the
-    /// PRNG.
-    pub fn register_type(app: &mut App) {
-        app.register_type::<Self>();
-        app.register_type::<R::Seed>();
-    }
-}
-
-impl<R: SeedableEntropySource> GlobalRngSeed<R>
-where
-    R::Seed: Sync + Send + Clone,
-{
-    /// Set the global seed to a new value
-    pub fn set_seed(&mut self, seed: R::Seed) {
-        self.seed = seed;
-    }
-}
-
-impl<R: SeedableEntropySource> Default for GlobalRngSeed<R>
-where
-    R::Seed: Sync + Send + Clone,
-{
-    #[inline]
-    fn default() -> Self {
-        Self::from_entropy()
-    }
-}
-
-impl<R: SeedableEntropySource> AsMut<[u8]> for GlobalRngSeed<R>
-where
-    R::Seed: Sync + Send + Clone,
-{
-    #[inline]
-    fn as_mut(&mut self) -> &mut [u8] {
-        self.seed.as_mut()
-    }
-}
 
 /// The initial seed/state for an [`EntropyComponent`]. Adding this component to an `Entity` will cause
 /// an `EntropyComponent` to be initialised as well. To force a reseed, just insert this component to an
@@ -168,19 +75,19 @@ mod tests {
     fn reflection_serialization_round_trip_works() {
         use bevy::reflect::{
             serde::{TypedReflectDeserializer, TypedReflectSerializer},
-            GetTypeRegistration, TypeRegistry,
+            FromReflect, GetTypeRegistration, TypeRegistry,
         };
         use bevy_prng::WyRand;
         use ron::to_string;
         use serde::de::DeserializeSeed;
 
         let mut registry = TypeRegistry::default();
-        registry.register::<GlobalRngSeed<WyRand>>();
+        registry.register::<RngSeed<WyRand>>();
         registry.register::<[u8; 8]>();
 
-        let registered_type = GlobalRngSeed::<WyRand>::get_type_registration();
+        let registered_type = RngSeed::<WyRand>::get_type_registration();
 
-        let val = GlobalRngSeed::<WyRand>::from_seed(u64::MAX.to_ne_bytes());
+        let val = RngSeed::<WyRand>::from_seed(u64::MAX.to_ne_bytes());
 
         let ser = TypedReflectSerializer::new(&val, &registry);
 
@@ -195,10 +102,10 @@ mod tests {
         let value = de.deserialize(&mut deserializer).unwrap();
 
         assert!(value.is_dynamic());
-        assert!(value.represents::<GlobalRngSeed<WyRand>>());
-        assert!(!value.is::<GlobalRngSeed<WyRand>>());
+        assert!(value.represents::<RngSeed<WyRand>>());
+        assert!(!value.is::<RngSeed<WyRand>>());
 
-        let recreated = GlobalRngSeed::<WyRand>::from_reflect(value.as_reflect()).unwrap();
+        let recreated = RngSeed::<WyRand>::from_reflect(value.as_reflect()).unwrap();
 
         assert_eq!(val.clone_seed(), recreated.clone_seed());
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -174,7 +174,7 @@ pub trait ForkableAsSeed<S: SeedableEntropySource>: EcsEntropySource {
     }
 }
 
-/// A trait for providing [`crate::seed::GlobalRngSeed`] and [`crate::seed::RngSeed`] with
+/// A trait for providing [`crate::seed::RngSeed`] with
 /// common initialization strategies. This trait is not object safe and is also a sealed trait.
 pub trait SeedSource<R: SeedableEntropySource>: private::SealedSeed<R>
 where

--- a/tests/integration/determinism.rs
+++ b/tests/integration/determinism.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_prng::{ChaCha12Rng, ChaCha8Rng, WyRand};
 use bevy_rand::prelude::{
-    EntropyComponent, EntropyPlugin, ForkableAsRng, ForkableRng, GlobalEntropy, GlobalRngSeed, SeedSource
+    EntropyComponent, EntropyPlugin, ForkableAsRng, ForkableRng, GlobalEntropy,
 };
 use rand::prelude::Rng;
 
@@ -87,8 +87,8 @@ fn setup_sources(mut commands: Commands, mut rng: ResMut<GlobalEntropy<ChaCha8Rn
     commands.spawn((SourceE, rng.fork_as::<WyRand>()));
 }
 
-fn read_global_seed(seed: Res<GlobalRngSeed<ChaCha8Rng>>) {
-    assert_eq!(seed.get_seed(), &[2; 32]);
+fn read_global_seed(rng: Res<GlobalEntropy<ChaCha8Rng>>) {
+    assert_eq!(rng.get_seed(), &[2; 32]);
 }
 
 /// Entities having their own sources side-steps issues with parallel execution and scheduling


### PR DESCRIPTION
Yeet `GlobalRngSeed` and instead roll the initial seed info into `GlobalEntropy`, so that reseeding will automatically reinitialise the RNG and to better associate/track the initial seed for reflection purposes.