### PR TITLE
feat: Add ForkableInnerSeed trait, observer tests, fixes

### DIFF
--- a/bevy_prng/src/lib.rs
+++ b/bevy_prng/src/lib.rs
@@ -62,13 +62,14 @@ pub trait SeedableEntropySource:
 {
 }
 
-/// Marker trait for a suitable seed for [`SeedableEntropySource`]. This is an auto trait which will 
+/// Marker trait for a suitable seed for [`SeedableEntropySource`]. This is an auto trait which will
 /// apply to all suitable types that meet the trait criteria.
 #[cfg(feature = "serialize")]
 pub trait EntropySeed:
     Debug
     + Default
     + PartialEq
+    + AsMut<[u8]>
     + Clone
     + Sync
     + Send
@@ -86,6 +87,7 @@ impl<
         T: Debug
             + Default
             + PartialEq
+            + AsMut<[u8]>
             + Clone
             + Sync
             + Send
@@ -108,6 +110,7 @@ pub trait SeedableEntropySource:
     + Clone
     + Debug
     + PartialEq
+    + AsMut<[u8]>
     + Reflect
     + TypePath
     + FromReflect
@@ -119,13 +122,13 @@ pub trait SeedableEntropySource:
 }
 
 #[cfg(not(feature = "serialize"))]
-/// Marker trait for a suitable seed for [`SeedableEntropySource`]. This is an auto trait which will 
+/// Marker trait for a suitable seed for [`SeedableEntropySource`]. This is an auto trait which will
 /// apply to all suitable types that meet the trait criteria.
 pub trait EntropySeed:
     Debug
     + Default
-    + AsMut<u8>
     + PartialEq
+    + AsMut<u8>
     + Clone
     + Sync
     + Send
@@ -141,6 +144,7 @@ impl<
         T: Debug
             + Default
             + PartialEq
+            + AsMut<[u8]>
             + Clone
             + Sync
             + Send

--- a/src/component.rs
+++ b/src/component.rs
@@ -3,8 +3,8 @@ use std::fmt::Debug;
 use crate::{
     seed::RngSeed,
     traits::{
-        EcsEntropySource, ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng,
-        ForkableSeed,
+        EcsEntropySource, ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableInnerSeed,
+        ForkableRng, ForkableSeed,
     },
 };
 use bevy::prelude::{Component, Reflect, ReflectComponent, ReflectFromReflect};
@@ -221,6 +221,14 @@ where
     R: SeedableEntropySource + 'static,
 {
     type Output<T> = RngSeed<T> where T: SeedableEntropySource, T::Seed: Send + Sync + Clone;
+}
+
+impl<R> ForkableInnerSeed<R> for EntropyComponent<R>
+where
+    R: SeedableEntropySource + 'static,
+    R::Seed: Send + Sync + Clone + AsMut<[u8]> + Default,
+{
+    type Output = R::Seed;
 }
 
 #[cfg(test)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,7 +3,8 @@ pub use crate::plugin::EntropyPlugin;
 pub use crate::resource::GlobalEntropy;
 pub use crate::seed::RngSeed;
 pub use crate::traits::{
-    ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng, ForkableSeed, SeedSource,
+    ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableInnerSeed, ForkableRng, ForkableSeed,
+    SeedSource,
 };
 #[cfg(feature = "wyrand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -4,8 +4,8 @@ use crate::{
     component::EntropyComponent,
     seed::RngSeed,
     traits::{
-        EcsEntropySource, ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableRng,
-        ForkableSeed,
+        EcsEntropySource, ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableInnerSeed,
+        ForkableRng, ForkableSeed,
     },
 };
 use bevy::prelude::{Reflect, ReflectFromReflect, ReflectFromWorld, ReflectResource, Resource};
@@ -198,6 +198,14 @@ where
     R::Seed: Clone,
 {
     type Output<T> = RngSeed<T> where T: SeedableEntropySource, T::Seed: Send + Sync + Clone;
+}
+
+impl<R> ForkableInnerSeed<R> for GlobalEntropy<R>
+where
+    R: SeedableEntropySource + 'static,
+    R::Seed: Send + Sync + Clone + AsMut<[u8]> + Default,
+{
+    type Output = R::Seed;
 }
 
 #[cfg(test)]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -174,6 +174,43 @@ pub trait ForkableAsSeed<S: SeedableEntropySource>: EcsEntropySource {
     }
 }
 
+/// Trait for implementing forking behaviour for [`crate::component::EntropyComponent`] and [`crate::resource::GlobalEntropy`].
+/// Forking creates a new RNG instance using a generated seed from the original source. If the original is seeded with a known
+/// seed, this process is deterministic. This trait enables forking from an entropy source to a seed component.
+pub trait ForkableInnerSeed<S: SeedableEntropySource>: EcsEntropySource
+where
+    S::Seed: Send + Sync + Clone + AsMut<[u8]> + Default,
+{
+    /// The type of seed component that is to be forked from the original source.
+    type Output: Send + Sync + Clone + AsMut<[u8]> + Default;
+
+    /// Fork a new seed from the original entropy source.
+    /// This method preserves the RNG algorithm between original instance and forked seed.
+    /// ```
+    /// use bevy::prelude::*;
+    /// use bevy_prng::ChaCha8Rng;
+    /// use bevy_rand::prelude::{GlobalEntropy, ForkableSeed};
+    ///
+    /// #[derive(Component)]
+    /// struct Source;
+    ///
+    /// fn setup_source(mut commands: Commands, mut global: ResMut<GlobalEntropy<ChaCha8Rng>>) {
+    ///     commands
+    ///         .spawn((
+    ///             Source,
+    ///             global.fork_seed(),
+    ///         ));
+    /// }
+    /// ```
+    fn fork_inner_seed(&mut self) -> Self::Output {
+        let mut seed = Self::Output::default();
+
+        self.fill_bytes(seed.as_mut());
+
+        seed
+    }
+}
+
 /// A trait for providing [`crate::seed::RngSeed`] with
 /// common initialization strategies. This trait is not object safe and is also a sealed trait.
 pub trait SeedSource<R: SeedableEntropySource>: private::SealedSeed<R>

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -176,7 +176,7 @@ pub trait ForkableAsSeed<S: SeedableEntropySource>: EcsEntropySource {
 
 /// Trait for implementing forking behaviour for [`crate::component::EntropyComponent`] and [`crate::resource::GlobalEntropy`].
 /// Forking creates a new RNG instance using a generated seed from the original source. If the original is seeded with a known
-/// seed, this process is deterministic. This trait enables forking from an entropy source to a seed component.
+/// seed, this process is deterministic. This trait enables forking from an entropy source to the RNG's seed type.
 pub trait ForkableInnerSeed<S: SeedableEntropySource>: EcsEntropySource
 where
     S::Seed: Send + Sync + Clone + AsMut<[u8]> + Default,
@@ -189,7 +189,7 @@ where
     /// ```
     /// use bevy::prelude::*;
     /// use bevy_prng::ChaCha8Rng;
-    /// use bevy_rand::prelude::{GlobalEntropy, ForkableSeed};
+    /// use bevy_rand::prelude::{GlobalEntropy, ForkableInnerSeed, SeedSource, RngSeed};
     ///
     /// #[derive(Component)]
     /// struct Source;
@@ -198,7 +198,7 @@ where
     ///     commands
     ///         .spawn((
     ///             Source,
-    ///             global.fork_seed(),
+    ///             RngSeed::<ChaCha8Rng>::from_seed(global.fork_inner_seed()),
     ///         ));
     /// }
     /// ```

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -206,7 +206,7 @@ fn observer_global_reseeding() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn observer_component_reseeding() {
+fn observer_children_reseeding() {
     use bevy::prelude::{
         Component, Entity, EntityWorldMut, Event, Last, PostUpdate, PreUpdate, Startup, Trigger,
         With, Without, World,

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -260,9 +260,15 @@ fn observer_children_reseeding() {
         .add_systems(
             Startup,
             |mut commands: Commands, mut source: ResMut<GlobalEntropy<WyRand>>| {
-                let mut source = commands.spawn(source.fork_seed());
+                let seed = source.fork_seed();
+
+                // Ensure the forked seed and original source don't match
+                assert_ne!(source.get_seed(), seed.get_seed());
+
+                let mut source = commands.spawn(seed);
 
                 source.add(|mut entity: EntityWorldMut| {
+                    // FORK! Quicker than allocating a new Vec of components to spawn.
                     let mut rng = entity
                         .get_mut::<EntropyComponent<WyRand>>()
                         .unwrap()

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -234,7 +234,7 @@ fn observer_children_reseeding() {
             let seed = trigger.event();
             entity_commands.insert(RngSeed::<WyRand>::from_seed(seed.0));
 
-            if q_children.get(entity).is_ok() {
+            if q_children.contains(entity) {
                 commands.trigger_targets(ReseedChildren, entity);
             }
         }


### PR DESCRIPTION
Adds a missing corollary to the other `Forkable...` traits, but for outputting a forked seed type directly (instead of a component). Also adds observer tests on how reseeding via observers might occur, including reseeding related entities.

Included with the PR are a bunch of small fixes as well.