### PR TITLE
Bump Bevy to 0.15.0-rc.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.8.0"
 rust-version = "1.76.0"
 
 [workspace.dependencies]
-bevy = { version = "0.14", default-features = false }
+bevy = { version = "0.15.0-rc.3", default-features = false }
 serde = "1"
 serde_derive = "1"
 rand_core = { version = "0.6", features = ["std"] }

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ fn setup_npc_from_source(
 - **`serialize`** - Enables `Serialize` and `Deserialize` derives. Enabled by default.
 - **`rand_chacha`** - This enables the exporting of newtyped `ChaCha*Rng` structs, for those that want/need to use a CSPRNG level source.
 - **`rand_pcg`** - This enables the exporting of newtyped `Pcg*` structs from `rand_pcg`.
-- **`rand_xoshiro`** - This enables the exporting of newtyped `Xoshiro*` structs from `rand_xoshiro`. It also reexports `Seed512` so to allow setting up `Xoshiro512StarStar` and so forth without the need to pull in `rand_xoshiro` explicitly.
+- **`rand_xoshiro`** - This enables the exporting of newtyped `Xoshiro*` structs from `rand_xoshiro`.
 - **`wyrand`** - This enables the exporting of newtyped `WyRand` from `wyrand`, the same algorithm in use within `fastrand`/`turborand`.
 
 ## Supported Versions & MSRV

--- a/bevy_prng/README.md
+++ b/bevy_prng/README.md
@@ -15,7 +15,7 @@ By default, `bevy_prng` won't export anything _unless_ the feature/algorithm you
 
 - **`rand_chacha`** - This enables the exporting of newtyped `ChaCha*Rng` structs, for those that want/need to use a CSPRNG level source.
 - **`rand_pcg`** - This enables the exporting of newtyped `Pcg*` structs from `rand_pcg`.
-- **`rand_xoshiro`** - This enables the exporting of newtyped `Xoshiro*` structs from `rand_xoshiro`. It also reexports `Seed512` so to allow setting up `Xoshiro512StarStar` and so forth without the need to pull in `rand_xoshiro` explicitly.
+- **`rand_xoshiro`** - This enables the exporting of newtyped `Xoshiro*` structs from `rand_xoshiro`.
 - **`wyrand`** - This enables the exporting of newtyped `WyRand` from `wyrand`, the same algorithm in use within `fastrand`/`turborand`.
 
 In addition to these feature flags to enable various supported algorithms, there's also **`serialize`** flag to provide `serde` support for `Serialize`/`Deserialize`, which is enabled by default.

--- a/bevy_prng/src/lib.rs
+++ b/bevy_prng/src/lib.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 
 use bevy::{
     prelude::{FromReflect, Reflect},
-    reflect::{GetTypeRegistration, TypePath},
+    reflect::{GetTypeRegistration, TypePath, Typed},
 };
 use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "serialize")]
@@ -46,7 +46,7 @@ pub use xoshiro::*;
 #[cfg(feature = "serialize")]
 pub trait SeedableEntropySource:
     RngCore
-    + SeedableRng
+    + SeedableRng<Seed: Typed>
     + Clone
     + Debug
     + PartialEq
@@ -56,6 +56,7 @@ pub trait SeedableEntropySource:
     + TypePath
     + FromReflect
     + GetTypeRegistration
+    + Typed
     + Serialize
     + for<'a> Deserialize<'a>
     + private::SealedSeedable
@@ -106,7 +107,7 @@ impl<
 #[cfg(not(feature = "serialize"))]
 pub trait SeedableEntropySource:
     RngCore
-    + SeedableRng
+    + SeedableRng<Seed: Typed>
     + Clone
     + Debug
     + PartialEq
@@ -115,6 +116,7 @@ pub trait SeedableEntropySource:
     + TypePath
     + FromReflect
     + GetTypeRegistration
+    + Typed
     + Sync
     + Send
     + private::SealedSeedable

--- a/bevy_prng/src/lib.rs
+++ b/bevy_prng/src/lib.rs
@@ -33,9 +33,6 @@ use serde::{Deserialize, Serialize};
 pub use chacha::*;
 #[cfg(feature = "rand_pcg")]
 pub use pcg::*;
-#[cfg(feature = "rand_xoshiro")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_xoshiro")))]
-pub use rand_xoshiro::Seed512;
 #[cfg(feature = "wyrand")]
 pub use wyrand::WyRand;
 #[cfg(feature = "rand_xoshiro")]

--- a/bevy_prng/src/newtype.rs
+++ b/bevy_prng/src/newtype.rs
@@ -8,11 +8,11 @@ macro_rules! newtype_prng {
         )]
         #[cfg_attr(
             all(feature = "serialize"),
-            reflect_value(Debug, PartialEq, FromReflect, Serialize, Deserialize)
+            reflect(opaque, Debug, PartialEq, FromReflect, Serialize, Deserialize)
         )]
         #[cfg_attr(
             all(not(feature = "serialize")),
-            reflect_value(Debug, PartialEq, FromReflect)
+            reflect(opaque, Debug, PartialEq, FromReflect)
         )]
         #[cfg_attr(docsrs, doc(cfg(feature = $feature)))]
         #[type_path = "bevy_prng"]

--- a/bevy_prng/src/xoshiro.rs
+++ b/bevy_prng/src/xoshiro.rs
@@ -7,27 +7,6 @@ use rand_core::{RngCore, SeedableRng};
 use bevy::prelude::{ReflectDeserialize, ReflectSerialize};
 
 newtype_prng!(
-    Xoshiro512StarStar,
-    ::rand_xoshiro::Xoshiro512StarStar,
-    "A newtyped [`rand_xoshiro::Xoshiro512StarStar`] RNG",
-    "rand_xoshiro"
-);
-
-newtype_prng!(
-    Xoshiro512PlusPlus,
-    ::rand_xoshiro::Xoshiro512PlusPlus,
-    "A newtyped [`rand_xoshiro::Xoshiro512PlusPlus`] RNG",
-    "rand_xoshiro"
-);
-
-newtype_prng!(
-    Xoshiro512Plus,
-    ::rand_xoshiro::Xoshiro512Plus,
-    "A newtyped [`rand_xoshiro::Xoshiro512Plus`] RNG",
-    "rand_xoshiro"
-);
-
-newtype_prng!(
     Xoshiro256StarStar,
     ::rand_xoshiro::Xoshiro256StarStar,
     "A newtyped [`rand_xoshiro::Xoshiro256StarStar`] RNG",

--- a/src/component.rs
+++ b/src/component.rs
@@ -295,7 +295,7 @@ mod tests {
     fn rng_untyped_serialization() {
         use bevy::reflect::{
             serde::{ReflectDeserializer, ReflectSerializer},
-            TypeRegistry,
+            FromReflect, TypeRegistry,
         };
         use ron::to_string;
         use serde::de::DeserializeSeed;
@@ -323,7 +323,7 @@ mod tests {
 
         let value = de.deserialize(&mut deserializer).unwrap();
 
-        let mut dynamic = value.take::<EntropyComponent<ChaCha8Rng>>().unwrap();
+        let mut dynamic = EntropyComponent::<ChaCha8Rng>::take_from_reflect(value).unwrap();
 
         // The two instances should be the same
         assert_eq!(
@@ -343,7 +343,7 @@ mod tests {
     fn rng_typed_serialization() {
         use bevy::reflect::{
             serde::{TypedReflectDeserializer, TypedReflectSerializer},
-            GetTypeRegistration, TypeRegistry,
+            FromReflect, GetTypeRegistration, TypeRegistry,
         };
         use ron::ser::to_string;
         use serde::de::DeserializeSeed;
@@ -373,7 +373,7 @@ mod tests {
 
         let value = de.deserialize(&mut deserializer).unwrap();
 
-        let mut dynamic = value.take::<EntropyComponent<ChaCha8Rng>>().unwrap();
+        let mut dynamic = EntropyComponent::<ChaCha8Rng>::take_from_reflect(value).unwrap();
 
         // The two instances should be the same
         assert_eq!(

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,5 +1,8 @@
 use crate::{component::EntropyComponent, resource::GlobalEntropy, seed::RngSeed};
-use bevy::prelude::{App, Plugin};
+use bevy::{
+    prelude::{App, Plugin},
+    reflect::Typed,
+};
 use bevy_prng::{EntropySeed, SeedableEntropySource};
 use rand_core::SeedableRng;
 
@@ -60,9 +63,9 @@ where
     }
 }
 
-impl<R: SeedableEntropySource + 'static> Plugin for EntropyPlugin<R>
+impl<R: SeedableEntropySource + Typed + 'static> Plugin for EntropyPlugin<R>
 where
-    R::Seed: EntropySeed,
+    R::Seed: EntropySeed + Typed,
 {
     fn build(&self, app: &mut App) {
         app.register_type::<GlobalEntropy<R>>()

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,8 +1,5 @@
 use crate::{component::EntropyComponent, resource::GlobalEntropy, seed::RngSeed};
-use bevy::{
-    prelude::{App, Plugin},
-    reflect::Typed,
-};
+use bevy::prelude::{App, Plugin};
 use bevy_prng::{EntropySeed, SeedableEntropySource};
 use rand_core::SeedableRng;
 
@@ -63,9 +60,9 @@ where
     }
 }
 
-impl<R: SeedableEntropySource + Typed + 'static> Plugin for EntropyPlugin<R>
+impl<R: SeedableEntropySource + 'static> Plugin for EntropyPlugin<R>
 where
-    R::Seed: EntropySeed + Typed,
+    R::Seed: EntropySeed,
 {
     fn build(&self, app: &mut App) {
         app.register_type::<GlobalEntropy<R>>()

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,5 +23,5 @@ pub use bevy_prng::{Pcg32, Pcg64, Pcg64Mcg};
 pub use bevy_prng::{
     Xoroshiro128Plus, Xoroshiro128PlusPlus, Xoroshiro128StarStar, Xoroshiro64Star,
     Xoroshiro64StarStar, Xoshiro128Plus, Xoshiro128PlusPlus, Xoshiro128StarStar, Xoshiro256Plus,
-    Xoshiro256PlusPlus, Xoshiro256StarStar, Xoshiro512Plus, Xoshiro512PlusPlus, Xoshiro512StarStar,
+    Xoshiro256PlusPlus, Xoshiro256StarStar,
 };

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -8,10 +8,7 @@ use crate::{
         ForkableRng, ForkableSeed,
     },
 };
-use bevy::{
-    prelude::{Reflect, ReflectFromReflect, ReflectFromWorld, ReflectResource, Resource},
-    reflect::Typed,
-};
+use bevy::prelude::{Reflect, ReflectFromReflect, ReflectFromWorld, ReflectResource, Resource};
 use bevy_prng::SeedableEntropySource;
 use rand_core::{RngCore, SeedableRng};
 
@@ -65,8 +62,8 @@ use serde::{Deserialize, Serialize};
     feature = "serialize",
     serde(bound(deserialize = "R: for<'a> Deserialize<'a>, R::Seed: for<'a> Deserialize<'a>"))
 )]
-#[cfg_attr(feature = "serialize", reflect(where R::Seed: PartialEq + Debug + Sync + Send + Clone + Serialize + Typed + for<'a> Deserialize<'a>))]
-#[cfg_attr(not(feature = "serialize"), reflect(where R::Seed: PartialEq + Debug + Sync + Send + Clone + Typed))]
+#[cfg_attr(feature = "serialize", reflect(where R::Seed: PartialEq + Debug + Sync + Send + Clone + Serialize + for<'a> Deserialize<'a>))]
+#[cfg_attr(not(feature = "serialize"), reflect(where R::Seed: PartialEq + Debug + Sync + Send + Clone))]
 pub struct GlobalEntropy<R: SeedableEntropySource + 'static> {
     seed: R::Seed,
     rng: R,

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -103,9 +103,9 @@ mod tests {
 
         assert!(value.is_dynamic());
         assert!(value.represents::<RngSeed<WyRand>>());
-        assert!(!value.is::<RngSeed<WyRand>>());
+        assert!(!value.try_downcast_ref::<RngSeed<WyRand>>().is_some());
 
-        let recreated = RngSeed::<WyRand>::from_reflect(value.as_reflect()).unwrap();
+        let recreated = RngSeed::<WyRand>::from_reflect(value.as_ref()).unwrap();
 
         assert_eq!(val.clone_seed(), recreated.clone_seed());
     }

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -199,7 +199,7 @@ fn observer_global_reseeding() {
                 .zip(seeds.map(u64::from_ne_bytes))
                 .for_each(|(expected, actual)| assert_ne!(expected, actual));
         })
-        .observe(reseed);
+        .add_observer(reseed);
 
     app.run();
 }
@@ -278,7 +278,7 @@ fn observer_children_reseeding() {
 
                 let mut source = commands.spawn(seed);
 
-                source.add(|mut entity: EntityWorldMut| {
+                source.queue(|mut entity: EntityWorldMut| {
                     // FORK! Quicker than allocating a new Vec of components to spawn.
                     let mut rng = entity
                         .get_mut::<EntropyComponent<WyRand>>()
@@ -361,8 +361,8 @@ fn observer_children_reseeding() {
                 assert_eq!(children.iter().size_hint().0, 5);
             },
         )
-        .observe(reseed)
-        .observe(reseed_children);
+        .add_observer(reseed)
+        .add_observer(reseed_children);
 
     app.run();
 }

--- a/tutorial/01-choosing-prng.md
+++ b/tutorial/01-choosing-prng.md
@@ -61,7 +61,7 @@ fn main() {
 The current set of PRNG algorithms that are supported out of the box in `bevy_prng` are as follows:
 
 - `wyrand`: This provides newtyped `WyRand` from `wyrand`, the same algorithm in use within `fastrand`/`turborand`.
-- `rand_xoshiro`: This provides newtyped `Xoshiro*` structs from `rand_xoshiro`. It also reexports `Seed512` so to allow setting up `Xoshiro512StarStar` and so forth without the need to pull in `rand_xoshiro` explicitly.
+- `rand_xoshiro`: This provides newtyped `Xoshiro*` structs from `rand_xoshiro`.
 - `rand_pcg`: This provides newtyped `Pcg*` structs from `rand_pcg`.
 - `rand_chacha`: This provides newtyped `ChaCha*Rng` structs, for those that want/need to use a CSPRNG level source.
 


### PR DESCRIPTION
Now we're ready for the 0.15 release!

Some notable weirdness to this bump: `Reflect` has been split into `PartialReflect` and `Reflect`. TL;DR - `PartialReflect` just means that you can access the fields of the represented type. `Reflect` on the other hand is an actual instance of the represented type. (or at least something like that). Regardless, `ReflectDeserializer` now spits out `PartialReflect` types, which means we need to do more work to extract the correct types.