### PR TITLE
feat: Use clippy instead of check for better lint enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,10 @@ jobs:
       - name: Install Rust
         # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
         run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+        # Install Clippy if we are on a nightly run.
       - name: Install Clippy
         run: rustup component add clippy
+        if: startsWith(matrix.rust, 'nightly')
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,9 @@ jobs:
       - name: Install wasm-pack
         uses: taiki-e/install-action@wasm-pack
         if: startsWith(matrix.os, 'ubuntu')
-      - name: Run cargo check
-        run: cargo check --all --all-features --all-targets
+      - name: Run clippy
+        run: cargo clippy --workspace --all-features --all-targets -- -Dwarnings
         if: startsWith(matrix.rust, 'nightly')
-      - name: Run cargo check (without dev-dependencies to catch missing feature flags)
-        if: startsWith(matrix.rust, 'nightly')
-        run: cargo check -Z features=dev_dep
       - run: cargo test --all-features
       - name: Test wasm
         run: wasm-pack test --headless --chrome --firefox -- --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Install Rust
         # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
         run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      - name: Install Clippy
+        run: rustup component add clippy
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: startsWith(matrix.os, 'ubuntu')

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ use bevy_prng::WyRand;
 use bevy_rand::prelude::EntropyPlugin;
 use rand_core::RngCore;
 
-fn main() {
+fn example_main() {
     App::new()
         .add_plugins(EntropyPlugin::<WyRand>::default())
         .run();


### PR DESCRIPTION
Remove old deprecated cargo checks and default to using clippy instead of `cargo check` so that lints and warnings can be upgraded to errors in CI.