### PR TITLE
refactor: Rename components/traits to shorter names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/Bluefinger/bevy_rand"
 license = "MIT OR Apache-2.0"
-version = "0.8.1"
+version = "0.9.0"
 rust-version = "1.76.0"
 
 [workspace.dependencies]
@@ -49,7 +49,7 @@ wyrand = ["bevy_prng/wyrand"]
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 bevy_reflect.workspace = true
-bevy_prng = { path = "bevy_prng", version = "0.8" }
+bevy_prng = { path = "bevy_prng", version = "0.9" }
 
 # others
 getrandom = "0.2"
@@ -63,10 +63,10 @@ serde_derive = { workspace = true, optional = true }
 # cannot be out of step with bevy_rand due to dependencies on traits
 # and implementations between the two crates.
 [target.'cfg(any())'.dependencies]
-bevy_prng = { path = "bevy_prng", version = "=0.8" }
+bevy_prng = { path = "bevy_prng", version = "=0.9" }
 
 [dev-dependencies]
-bevy_prng = { path = "bevy_prng", version = "0.8", features = ["rand_chacha", "wyrand"] }
+bevy_prng = { path = "bevy_prng", version = "0.9", features = ["rand_chacha", "wyrand"] }
 rand = "0.8"
 ron = { version = "0.8.0", features = ["integer128"] }
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -27,3 +27,7 @@ As the `wyrand` dependency has been updated and contains a breaking output chang
 ## Migrating from v0.7 to v0.8
 
 `GlobalRngSeed` has been removed, instead being rolled into `GlobalEntropy`. This will allow better reflection tracking of the global rng source, and will allow for automatic reseeding without any custom system needing to be provided. Use the `reseed` method to reinstantiate the internal RNG source with the new seed, and `get_seed` to return a reference to the initial starting seed for the source. The serialized format of `GlobalEntropy` has changed and previously serialized instances are no longer compatible.
+
+## Migrating from v0.8 to v0.9
+
+`EntropyComponent` has been renamed to `Entropy`, and the trait `SeedableEntropySource` has been renamed to `EntropySource`. The change to `Entropy` also changes the `TypePath` definition, so this will change the serialised format of the component.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ DO **NOT** use `bevy_rand` for actual security purposes, as this requires much m
 
 ### Registering a PRNG for use with Bevy Rand
 
-Before a PRNG can be used via `GlobalEntropy` or `EntropyComponent`, it must be registered via the plugin.
+Before a PRNG can be used via `GlobalEntropy` or `Entropy`, it must be registered via the plugin.
 
 ```rust
 use bevy_ecs::prelude::*;
@@ -69,7 +69,7 @@ fn print_random_value(mut rng: ResMut<GlobalEntropy<WyRand>>) {
 
 ### Forking RNGs
 
-For seeding `EntropyComponent`s from a global source, it is best to make use of forking instead of generating the seed value directly. `GlobalEntropy` can only exist as a singular instance, so when forking normally, it will always fork as `EntropyComponent` instances.
+For seeding `Entropy`s from a global source, it is best to make use of forking instead of generating the seed value directly. `GlobalEntropy` can only exist as a singular instance, so when forking normally, it will always fork as `Entropy` instances.
 
 ```rust
 use bevy_ecs::prelude::*;
@@ -88,12 +88,12 @@ fn setup_source(mut commands: Commands, mut global: ResMut<GlobalEntropy<WyRand>
 }
 ```
 
-`EntropyComponent`s can be seeded/forked from other `EntropyComponent`s as well.
+`Entropy`s can be seeded/forked from other `Entropy`s as well.
 
 ```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::prelude::{EntropyComponent, ForkableRng};
+use bevy_rand::prelude::{Entropy, ForkableRng};
 
 #[derive(Component)]
 struct Npc;
@@ -103,7 +103,7 @@ struct Source;
 
 fn setup_npc_from_source(
    mut commands: Commands,
-   mut q_source: Query<&mut EntropyComponent<WyRand>, (With<Source>, Without<Npc>)>,
+   mut q_source: Query<&mut Entropy<WyRand>, (With<Source>, Without<Npc>)>,
 ) {
    let mut source = q_source.single_mut();
    for _ in 0..2 {

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ fn setup_npc_from_source(
 
 | `bevy` | `bevy_rand`  |
 | ------ | ------------ |
-| v0.15  | v0.8         |
+| v0.15  | v0.8 - v0.9  |
 | v0.14  | v0.7         |
 | v0.13  | v0.5 - v0.6  |
 | v0.12  | v0.4         |
@@ -143,7 +143,7 @@ The versions of `rand_core`/`rand` that `bevy_rand` is compatible with is as fol
 
 | `bevy_rand`  | `rand_core` | `rand` |
 | ------------ | ----------- | ------ |
-| v0.1 -> v0.8 | v0.6        | v0.8   |
+| v0.1 -> v0.9 | v0.6        | v0.8   |
 
 ## Migrations
 

--- a/bevy_prng/src/chacha.rs
+++ b/bevy_prng/src/chacha.rs
@@ -1,4 +1,4 @@
-use crate::{newtype::newtype_prng, SeedableEntropySource};
+use crate::{newtype::newtype_prng, EntropySource};
 
 use bevy_reflect::{Reflect, ReflectFromReflect};
 use rand_core::{RngCore, SeedableRng};

--- a/bevy_prng/src/lib.rs
+++ b/bevy_prng/src/lib.rs
@@ -38,7 +38,7 @@ pub use xoshiro::*;
 /// A marker trait to define the required trait bounds for a seedable PRNG to
 /// integrate into `EntropyComponent` or `GlobalEntropy`. This is a sealed trait.
 #[cfg(feature = "serialize")]
-pub trait SeedableEntropySource:
+pub trait EntropySource:
     RngCore
     + SeedableRng<Seed: Typed>
     + Clone
@@ -54,7 +54,7 @@ pub trait SeedableEntropySource:
 {
 }
 
-/// Marker trait for a suitable seed for [`SeedableEntropySource`]. This is an auto trait which will
+/// Marker trait for a suitable seed for [`EntropySource`]. This is an auto trait which will
 /// apply to all suitable types that meet the trait criteria.
 #[cfg(feature = "serialize")]
 pub trait EntropySeed:
@@ -92,7 +92,7 @@ impl<
 /// A marker trait to define the required trait bounds for a seedable PRNG to
 /// integrate into `EntropyComponent` or `GlobalEntropy`. This is a sealed trait.
 #[cfg(not(feature = "serialize"))]
-pub trait SeedableEntropySource:
+pub trait EntropySource:
     RngCore
     + SeedableRng<Seed: Typed>
     + Clone
@@ -108,7 +108,7 @@ pub trait SeedableEntropySource:
 }
 
 #[cfg(not(feature = "serialize"))]
-/// Marker trait for a suitable seed for [`SeedableEntropySource`]. This is an auto trait which will
+/// Marker trait for a suitable seed for [`EntropySource`]. This is an auto trait which will
 /// apply to all suitable types that meet the trait criteria.
 pub trait EntropySeed:
     Debug
@@ -145,5 +145,5 @@ impl<
 mod private {
     pub trait SealedSeedable {}
 
-    impl<T: super::SeedableEntropySource> SealedSeedable for T {}
+    impl<T: super::EntropySource> SealedSeedable for T {}
 }

--- a/bevy_prng/src/newtype.rs
+++ b/bevy_prng/src/newtype.rs
@@ -72,7 +72,7 @@ macro_rules! newtype_prng {
             }
         }
 
-        impl SeedableEntropySource for $newtype {}
+        impl EntropySource for $newtype {}
     };
 }
 
@@ -150,7 +150,7 @@ macro_rules! newtype_prng_remote {
             }
         }
 
-        impl SeedableEntropySource for $newtype {}
+        impl EntropySource for $newtype {}
     };
 }
 

--- a/bevy_prng/src/pcg.rs
+++ b/bevy_prng/src/pcg.rs
@@ -1,4 +1,4 @@
-use crate::{newtype::newtype_prng, SeedableEntropySource};
+use crate::{newtype::newtype_prng, EntropySource};
 
 use bevy_reflect::{Reflect, ReflectFromReflect};
 use rand_core::{RngCore, SeedableRng};

--- a/bevy_prng/src/wyrand.rs
+++ b/bevy_prng/src/wyrand.rs
@@ -1,4 +1,4 @@
-use crate::{newtype::newtype_prng, SeedableEntropySource};
+use crate::{newtype::newtype_prng, EntropySource};
 
 use bevy_reflect::{Reflect, ReflectFromReflect};
 use rand_core::{RngCore, SeedableRng};

--- a/bevy_prng/src/xoshiro.rs
+++ b/bevy_prng/src/xoshiro.rs
@@ -1,6 +1,6 @@
 use crate::{
     newtype::{newtype_prng, newtype_prng_remote},
-    SeedableEntropySource,
+    EntropySource,
 };
 
 use bevy_reflect::{reflect_remote, std_traits::ReflectDefault, Reflect, ReflectFromReflect};

--- a/examples/turn_based_game.rs
+++ b/examples/turn_based_game.rs
@@ -3,7 +3,7 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_prng::ChaCha8Rng;
-use bevy_rand::prelude::{EntropyComponent, EntropyPlugin, ForkableRng, GlobalEntropy};
+use bevy_rand::prelude::{Entropy, EntropyPlugin, ForkableRng, GlobalEntropy};
 use rand::prelude::{IteratorRandom, Rng};
 
 #[derive(Component, PartialEq, Eq)]
@@ -97,7 +97,7 @@ fn setup_enemies(mut commands: Commands, mut rng: ResMut<GlobalEntropy<ChaCha8Rn
 }
 
 fn determine_attack_order(
-    mut q_entities: Query<(Entity, &mut EntropyComponent<ChaCha8Rng>), With<Kind>>,
+    mut q_entities: Query<(Entity, &mut Entropy<ChaCha8Rng>), With<Kind>>,
 ) -> Vec<Entity> {
     // No matter the order of entities in the query, because they have their own RNG instance,
     // it will always result in a deterministic output due to being seeded from a single global
@@ -121,7 +121,7 @@ fn attack_turn(
         &Defense,
         &Name,
         &mut Health,
-        &mut EntropyComponent<ChaCha8Rng>,
+        &mut Entropy<ChaCha8Rng>,
     )>,
 ) {
     // Establish list of enemy entities for player to attack
@@ -173,10 +173,7 @@ fn attack_turn(
 }
 
 fn buff_entities(
-    mut q_entities: Query<
-        (&Name, &Buff, &mut Health, &mut EntropyComponent<ChaCha8Rng>),
-        With<Kind>,
-    >,
+    mut q_entities: Query<(&Name, &Buff, &mut Health, &mut Entropy<ChaCha8Rng>), With<Kind>>,
 ) {
     // Query iteration order is not stable, but entities having their own RNG source side-steps this
     // completely, so the result is always deterministic.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use crate::component::EntropyComponent;
+pub use crate::component::Entropy;
 pub use crate::plugin::EntropyPlugin;
 pub use crate::resource::GlobalEntropy;
 pub use crate::seed::RngSeed;

--- a/tests/integration/determinism.rs
+++ b/tests/integration/determinism.rs
@@ -1,9 +1,7 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_prng::{ChaCha12Rng, ChaCha8Rng, WyRand};
-use bevy_rand::prelude::{
-    EntropyComponent, EntropyPlugin, ForkableAsRng, ForkableRng, GlobalEntropy,
-};
+use bevy_rand::prelude::{Entropy, EntropyPlugin, ForkableAsRng, ForkableRng, GlobalEntropy};
 use rand::prelude::Rng;
 
 use rand_core::RngCore;
@@ -26,7 +24,7 @@ struct SourceD;
 #[derive(Component)]
 struct SourceE;
 
-fn random_output_a(mut q_source: Query<&mut EntropyComponent<ChaCha8Rng>, With<SourceA>>) {
+fn random_output_a(mut q_source: Query<&mut Entropy<ChaCha8Rng>, With<SourceA>>) {
     let mut rng = q_source.single_mut();
 
     assert_eq!(
@@ -36,13 +34,13 @@ fn random_output_a(mut q_source: Query<&mut EntropyComponent<ChaCha8Rng>, With<S
     );
 }
 
-fn random_output_b(mut q_source: Query<&mut EntropyComponent<ChaCha8Rng>, With<SourceB>>) {
+fn random_output_b(mut q_source: Query<&mut Entropy<ChaCha8Rng>, With<SourceB>>) {
     let mut rng = q_source.single_mut();
 
     assert!(rng.gen_bool(0.5), "SourceB does not match expected output");
 }
 
-fn random_output_c(mut q_source: Query<&mut EntropyComponent<ChaCha8Rng>, With<SourceC>>) {
+fn random_output_c(mut q_source: Query<&mut Entropy<ChaCha8Rng>, With<SourceC>>) {
     let mut rng = q_source.single_mut();
 
     assert_eq!(
@@ -52,7 +50,7 @@ fn random_output_c(mut q_source: Query<&mut EntropyComponent<ChaCha8Rng>, With<S
     );
 }
 
-fn random_output_d(mut q_source: Query<&mut EntropyComponent<ChaCha12Rng>, With<SourceD>>) {
+fn random_output_d(mut q_source: Query<&mut Entropy<ChaCha12Rng>, With<SourceD>>) {
     let mut rng = q_source.single_mut();
 
     assert_eq!(
@@ -62,7 +60,7 @@ fn random_output_d(mut q_source: Query<&mut EntropyComponent<ChaCha12Rng>, With<
     );
 }
 
-fn random_output_e(mut q_source: Query<&mut EntropyComponent<WyRand>, With<SourceE>>) {
+fn random_output_e(mut q_source: Query<&mut Entropy<WyRand>, With<SourceE>>) {
     let mut rng = q_source.single_mut();
 
     let mut bytes = [0u8; 8];

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -3,7 +3,7 @@ use bevy_ecs::prelude::*;
 use bevy_prng::{ChaCha8Rng, WyRand};
 use bevy_rand::{
     plugin::EntropyPlugin,
-    prelude::EntropyComponent,
+    prelude::Entropy,
     resource::GlobalEntropy,
     traits::{ForkableAsSeed, ForkableSeed},
 };
@@ -71,21 +71,18 @@ fn component_fork_seed() {
                 }
             },
         )
-        .add_systems(
-            Update,
-            |mut q_rng: Query<&mut EntropyComponent<ChaCha8Rng>>| {
-                let rngs = q_rng.iter_mut();
+        .add_systems(Update, |mut q_rng: Query<&mut Entropy<ChaCha8Rng>>| {
+            let rngs = q_rng.iter_mut();
 
-                assert_eq!(rngs.size_hint().0, 5);
+            assert_eq!(rngs.size_hint().0, 5);
 
-                let values: Vec<_> = rngs.map(|mut rng| rng.next_u32()).collect();
+            let values: Vec<_> = rngs.map(|mut rng| rng.next_u32()).collect();
 
-                assert_eq!(
-                    &values,
-                    &[3315785188, 1951699392, 911252207, 791343233, 1599472206]
-                );
-            },
-        );
+            assert_eq!(
+                &values,
+                &[3315785188, 1951699392, 911252207, 791343233, 1599472206]
+            );
+        });
 
     app.update();
 }
@@ -106,7 +103,7 @@ fn component_fork_as_seed() {
                 }
             },
         )
-        .add_systems(Update, |mut q_rng: Query<&mut EntropyComponent<WyRand>>| {
+        .add_systems(Update, |mut q_rng: Query<&mut Entropy<WyRand>>| {
             let rngs = q_rng.iter_mut();
 
             assert_eq!(rngs.size_hint().0, 5);
@@ -171,7 +168,7 @@ fn observer_global_reseeding() {
         .add_systems(
             Update,
             |mut commands: Commands,
-             query: Query<Entity, With<EntropyComponent<WyRand>>>,
+             query: Query<Entity, With<Entropy<WyRand>>>,
              mut source: ResMut<GlobalEntropy<WyRand>>| {
                 for e in &query {
                     commands.trigger_targets(ReseedRng::<WyRand>::new(source.fork_inner_seed()), e);

--- a/tutorial/03-components-forking.md
+++ b/tutorial/03-components-forking.md
@@ -1,11 +1,11 @@
-# Entities as RNG sources with `EntropyComponent`
+# Entities as RNG sources with `Entropy`
 
-In order to move beyond the restrictions placed by `GlobalEntropy` and achieve determinism *with parallelism*, where the RNG source lives has to go from a global source to one owned by the entities themselves. `EntropyComponent` enables us to attach a PRNG to any given entity, and thus sidesteps not only forcing systems to run serially to each other, but also avoids the problem of queries not being stable in ordering. In fact, as ordering is no longer an issue, parallel iteration of queries is made possible as we avoid borrowing issues if each entity we queried owns its own RNG source.
+In order to move beyond the restrictions placed by `GlobalEntropy` and achieve determinism *with parallelism*, where the RNG source lives has to go from a global source to one owned by the entities themselves. `Entropy` enables us to attach a PRNG to any given entity, and thus sidesteps not only forcing systems to run serially to each other, but also avoids the problem of queries not being stable in ordering. In fact, as ordering is no longer an issue, parallel iteration of queries is made possible as we avoid borrowing issues if each entity we queried owns its own RNG source.
 
 ```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::prelude::EntropyComponent;
+use bevy_rand::prelude::Entropy;
 
 #[derive(Component)]
 struct Source;
@@ -14,17 +14,17 @@ fn setup_source(mut commands: Commands) {
     commands
         .spawn((
             Source,
-            EntropyComponent::<WyRand>::default(),
+            Entropy::<WyRand>::default(),
         ));
 }
 ```
 
-In the above example, we are creating an entity with a `Source` marker component and attaching an `EntropyComponent` to it with the `WyRand` algorithm and a randomised seed. To then access this source, we simply query `Query<&mut EntropyComponent<WyRand>, With<Source>>`. In this case, we are creating a single entity with an RNG source, but there's no reason why many more can't have an RNG source attached to them.
+In the above example, we are creating an entity with a `Source` marker component and attaching an `Entropy` to it with the `WyRand` algorithm and a randomised seed. To then access this source, we simply query `Query<&mut Entropy<WyRand>, With<Source>>`. In this case, we are creating a single entity with an RNG source, but there's no reason why many more can't have an RNG source attached to them.
 
 ```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::prelude::EntropyComponent;
+use bevy_rand::prelude::Entropy;
 
 #[derive(Component)]
 struct Npc;
@@ -34,7 +34,7 @@ fn setup_source(mut commands: Commands) {
         commands
             .spawn((
                 Npc,
-                EntropyComponent::<WyRand>::default(),
+                Entropy::<WyRand>::default(),
             ));
     }
 }
@@ -46,12 +46,12 @@ We can also instantiate these components with set seeds, but there's then the da
 
 Forking is the process of generating a new seed from an RNG source and creating a new RNG instance with it. If cloning creates a new instance with the same state from the old, forking creates a new instance with a new state, advancing the old instance's state in the process (as we used it to generate a new seed).
 
-Because PRNG algorithms are deterministic, forking is a deterministic process, and it allows us to have one seed state create many "random" states while being hard to predict. `bevy_rand` makes it super easy to fork new `EntropyComponent`s, allowing you to source new RNGs from `GlobalEntropy` or even other `EntropyComponent`s!
+Because PRNG algorithms are deterministic, forking is a deterministic process, and it allows us to have one seed state create many "random" states while being hard to predict. `bevy_rand` makes it super easy to fork new `Entropy`s, allowing you to source new RNGs from `GlobalEntropy` or even other `Entropy`s!
 
 ```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::ChaCha8Rng;
-use bevy_rand::prelude::{EntropyComponent, GlobalEntropy, ForkableRng};
+use bevy_rand::prelude::{Entropy, GlobalEntropy, ForkableRng};
 
 #[derive(Component)]
 struct Source;
@@ -60,7 +60,7 @@ fn setup_source(mut commands: Commands, mut global: ResMut<GlobalEntropy<ChaCha8
     commands
         .spawn((
             Source,
-            global.fork_rng(), // This will yield an `EntropyComponent<ChaCha8Rng>`
+            global.fork_rng(), // This will yield an `Entropy<ChaCha8Rng>`
         ));
 }
 ```
@@ -70,7 +70,7 @@ We can even fork to different PRNG algorithms.
 ```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::{ChaCha8Rng, WyRand};
-use bevy_rand::prelude::{EntropyComponent, GlobalEntropy, ForkableAsRng};
+use bevy_rand::prelude::{Entropy, GlobalEntropy, ForkableAsRng};
 
 #[derive(Component)]
 struct Source;
@@ -79,7 +79,7 @@ fn setup_source(mut commands: Commands, mut global: ResMut<GlobalEntropy<ChaCha8
     commands
         .spawn((
             Source,
-            global.fork_as::<WyRand>(), // This will yield an `EntropyComponent<WyRand>`
+            global.fork_as::<WyRand>(), // This will yield an `Entropy<WyRand>`
         ));
 }
 ```
@@ -89,7 +89,7 @@ So we created a `Source` entity with an RNG source, let's use it to spawn more e
 ```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::prelude::{EntropyComponent, ForkableRng};
+use bevy_rand::prelude::{Entropy, ForkableRng};
 
 #[derive(Component)]
 struct Npc;
@@ -99,14 +99,14 @@ struct Source;
 
 fn setup_npc_from_source(
    mut commands: Commands,
-   mut q_source: Query<&mut EntropyComponent<WyRand>, (With<Source>, Without<Npc>)>,
+   mut q_source: Query<&mut Entropy<WyRand>, (With<Source>, Without<Npc>)>,
 ) {
    let mut source = q_source.single_mut();
    for _ in 0..10 {
        commands
            .spawn((
                Npc,
-               source.fork_rng() // This will yield a new `EntropyComponent<WyRand>`
+               source.fork_rng() // This will yield a new `Entropy<WyRand>`
            ));
    }
 }
@@ -115,7 +115,7 @@ fn setup_npc_from_source(
 Now that we have our `Npc` entities attached with RNG sources, when we query them, we can make use of their own sources when generating new random numbers from them.
 
 ```rust ignore
-fn randomise_npc_stat(mut q_npc: Query<(&mut Stat, &mut EntropyComponent<WyRand>), With<Npc>>) {
+fn randomise_npc_stat(mut q_npc: Query<(&mut Stat, &mut Entropy<WyRand>), With<Npc>>) {
     for (mut stat, mut rng) in q_npc.iter_mut() {
         stat.0 = rng.next_u32();
     }
@@ -124,4 +124,4 @@ fn randomise_npc_stat(mut q_npc: Query<(&mut Stat, &mut EntropyComponent<WyRand>
 
 This way, no matter what order the query iterates, we can be assured that the resulting output is always deterministic. Other systems that access different entities with RNG sources that don't overlap with `Npc` entity systems will be able to run in parallel, and iterating the queries themselves can also be done in parallel with `.par_iter()`. We've ensured that each *access* is deterministic and owned to the entity itself.
 
-As a final note: for both `GlobalEntropy` and `EntropyComponent`s, one can fork the inner PRNG instance to use directly or pass into methods via `fork_inner()`.
+As a final note: for both `GlobalEntropy` and `Entropy`s, one can fork the inner PRNG instance to use directly or pass into methods via `fork_inner()`.


### PR DESCRIPTION
Renaming the component from `EntropyComponent` to just `Entropy` since it is a bit redundant otherwise. `SeedableEntropySource` is now just `EntropySource` since again, the trait constraints are enough to determine what is a valid source so no need to have a long name.