### PR TITLE
fix: Correct variable naming in from_entropy method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,10 @@ jobs:
       - name: Run clippy
         run: cargo clippy --workspace --all-features --all-targets -- -Dwarnings
         if: startsWith(matrix.rust, 'nightly')
-      - run: cargo test --all-features
+      - name: No Default Feature checks
+        run: cargo check --no-default-features
+      - name: Test with all features enabled
+        run: cargo test --all-features
       - name: Test wasm
         run: wasm-pack test --headless --chrome --firefox -- --all-features
         if: startsWith(matrix.os, 'ubuntu')

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -73,11 +73,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[cfg(feature = "serialize")]
     #[test]
     fn reflection_serialization_round_trip_works() {
+        use super::*;
+
         use bevy_prng::WyRand;
         use bevy_reflect::{
             serde::{TypedReflectDeserializer, TypedReflectSerializer},

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -244,7 +244,7 @@ where
         {
             use getrandom::getrandom;
 
-            getrandom(seed.as_mut()).expect("Unable to source entropy for seeding");
+            getrandom(dest.as_mut()).expect("Unable to source entropy for seeding");
         }
 
         Self::from_seed(dest)


### PR DESCRIPTION
Closes #37

Fix does what it says on the tin. Also as an extra, ensure this doesn't happen again with a CI check. Might have to do a setup to go and test as many feature permutations as possible, but that's for another PR and time.