### PR TITLE
fix: Better feature testing and default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Test wasm
         run: wasm-pack test --headless --chrome --firefox -- --all-features
         if: startsWith(matrix.os, 'ubuntu')
+      - name: Test wasm (no default features)
+        run: wasm-pack test --headless --chrome --firefox -- --no-default-features
+        if: startsWith(matrix.os, 'ubuntu')
   miri:
     name: "Miri"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: cargo clippy --workspace --all-features --all-targets -- -Dwarnings
         if: startsWith(matrix.rust, 'nightly')
       - name: No Default Feature checks
-        run: cargo check --no-default-features
+        run: cargo check --no-default-features --workspace
       - name: Test with all features enabled
         run: cargo test --all-features
       - name: Test wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bevy_ecs = { git = "https://github.com/bevyengine/bevy", package = "bevy_ecs" }
 bevy_reflect = { git = "https://github.com/bevyengine/bevy", package = "bevy_reflect", default-features = false }
 serde = "1"
 serde_derive = "1"
-rand_core = { version = "0.6" }
+rand_core = { version = "0.6", features = ["getrandom"]}
 rand_chacha = "0.3"
 wyrand = "0.2"
 rand_pcg = "0.3"
@@ -72,8 +72,6 @@ ron = { version = "0.8.0", features = ["integer128"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
-
-[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bevy_ecs = { git = "https://github.com/bevyengine/bevy", package = "bevy_ecs" }
 bevy_reflect = { git = "https://github.com/bevyengine/bevy", package = "bevy_reflect", default-features = false }
 serde = "1"
 serde_derive = "1"
-rand_core = { version = "0.6", features = ["getrandom"]}
+rand_core = { version = "0.6", features = ["getrandom"] }
 rand_chacha = "0.3"
 wyrand = "0.2"
 rand_pcg = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rust-version = { workspace = true }
 default = ["serialize", "thread_local_entropy"]
 experimental = []
 thread_local_entropy = ["dep:rand_chacha"]
-serialize = ["dep:serde", "dep:serde_derive", "rand_core/serde1"]
+serialize = ["dep:serde", "dep:serde_derive", "rand_core/serde1", "bevy_prng/serialize"]
 rand_chacha = ["bevy_prng/rand_chacha"]
 rand_pcg = ["bevy_prng/rand_pcg"]
 rand_xoshiro = ["bevy_prng/rand_xoshiro"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bevy_ecs = { git = "https://github.com/bevyengine/bevy", package = "bevy_ecs" }
 bevy_reflect = { git = "https://github.com/bevyengine/bevy", package = "bevy_reflect", default-features = false }
 serde = "1"
 serde_derive = "1"
-rand_core = { version = "0.6", features = ["std"] }
+rand_core = { version = "0.6" }
 rand_chacha = "0.3"
 wyrand = "0.2"
 rand_pcg = "0.3"

--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ fn setup_npc_from_source(
 }
 ```
 
+## Usage within Web WASM environments
+
+From `v0.9`, `bevy_rand` will no longer assume that `bevy` will be run in a web environment when compiled for WASM. To enable that, just paste the following into your `Cargo.toml` for your binary crate:
+
+```toml
+[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+```
+
+This is in preparation for the newer versions of `getrandom`, which will force users to select the correct entropy backend for their application, something that can no longer be done by library crates.
+
 ## Features
 
 - **`thread_local_entropy`** - Enables `ThreadLocalEntropy`, overriding `SeedableRng::from_entropy` implementations to make use of thread local entropy sources for faster PRNG initialisation. Enabled by default.

--- a/bevy_prng/Cargo.toml
+++ b/bevy_prng/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["/.*"]
 rust-version = { workspace = true }
 
 [features]
-default = ["serialize"]
+default = []
 serialize = [
     "dep:serde",
     "dep:serde_derive",

--- a/bevy_prng/Cargo.toml
+++ b/bevy_prng/Cargo.toml
@@ -22,6 +22,10 @@ serialize = [
     "rand_xoshiro?/serde1",
     "wyrand?/serde1",
 ]
+rand_chacha = ["dep:rand_chacha"]
+wyrand = ["dep:wyrand"]
+rand_pcg = ["dep:rand_pcg"]
+rand_xoshiro = ["dep:rand_xoshiro"]
 
 [dependencies]
 bevy_reflect.workspace = true

--- a/bevy_prng/src/lib.rs
+++ b/bevy_prng/src/lib.rs
@@ -111,33 +111,13 @@ pub trait EntropySource:
 /// Marker trait for a suitable seed for [`EntropySource`]. This is an auto trait which will
 /// apply to all suitable types that meet the trait criteria.
 pub trait EntropySeed:
-    Debug
-    + Default
-    + PartialEq
-    + AsMut<u8>
-    + Clone
-    + Sync
-    + Send
-    + Reflect
-    + TypePath
-    + FromReflect
-    + GetTypeRegistration //+ private::SealedSeed
+    Debug + Default + PartialEq + AsMut<[u8]> + Clone + Sync + Send + Reflectable + FromReflect
 {
 }
 
 #[cfg(not(feature = "serialize"))]
 impl<
-        T: Debug
-            + Default
-            + PartialEq
-            + AsMut<[u8]>
-            + Clone
-            + Sync
-            + Send
-            + Reflect
-            + TypePath
-            + FromReflect
-            + GetTypeRegistration,
+        T: Debug + Default + PartialEq + AsMut<[u8]> + Clone + Sync + Send + Reflectable + FromReflect,
     > EntropySeed for T
 {
 }

--- a/bevy_prng/src/lib.rs
+++ b/bevy_prng/src/lib.rs
@@ -98,7 +98,6 @@ pub trait EntropySource:
     + Clone
     + Debug
     + PartialEq
-    + AsMut<[u8]>
     + Reflectable
     + FromReflect
     + Sync


### PR DESCRIPTION
Closes #36 if successful.

Changing the feature setup for `bevy_rand` and `bevy_prng` to have better defaults, as well as removing the assumption for WASM builds being Web ones (leaving it to the application to define this, as this will be the incoming requirement changes for `getrandom`)