### PR TITLE
refactor: Relations, Command API and plugin-reorg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/Bluefinger/bevy_rand"
 license = "MIT OR Apache-2.0"
-version = "0.10.0"
+version = "0.11.0"
 rust-version = "1.76.0"
 
 [workspace.dependencies]
@@ -53,7 +53,7 @@ wyrand = ["bevy_prng/wyrand"]
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 bevy_reflect.workspace = true
-bevy_prng = { path = "bevy_prng", version = "0.10" }
+bevy_prng = { path = "bevy_prng", version = "0.11" }
 
 # others
 getrandom = "0.2"
@@ -66,7 +66,7 @@ serde = { workspace = true, optional = true }
 # cannot be out of step with bevy_rand due to dependencies on traits
 # and implementations between the two crates.
 [target.'cfg(any())'.dependencies]
-bevy_prng = { path = "bevy_prng", version = "=0.10" }
+bevy_prng = { path = "bevy_prng", version = "=0.11" }
 
 [dev-dependencies]
 bevy_app = { git = "https://github.com/bevyengine/bevy", package = "bevy_app", default-features = false, features = [
@@ -78,7 +78,7 @@ bevy_ecs = { git = "https://github.com/bevyengine/bevy", package = "bevy_ecs", d
     "multi_threaded",
     "async_executor",
 ] }
-bevy_prng = { path = "bevy_prng", version = "0.10", features = ["rand_chacha", "wyrand"] }
+bevy_prng = { path = "bevy_prng", version = "0.11", features = ["rand_chacha", "wyrand"] }
 rand = "0.8"
 ron = { version = "0.8.0", features = ["integer128"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [workspace]
 members = ["bevy_prng"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/Bluefinger/bevy_rand"
 license = "MIT OR Apache-2.0"
-version = "0.11.0"
-rust-version = "1.76.0"
+version = "0.10.0"
+rust-version = "1.85.0"
 
 [workspace.dependencies]
 bevy_app = { git = "https://github.com/bevyengine/bevy", package = "bevy_app", default-features = false, features = [
@@ -53,7 +53,7 @@ wyrand = ["bevy_prng/wyrand"]
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 bevy_reflect.workspace = true
-bevy_prng = { path = "bevy_prng", version = "0.11" }
+bevy_prng = { path = "bevy_prng", version = "0.10" }
 
 # others
 getrandom = "0.2"
@@ -66,7 +66,7 @@ serde = { workspace = true, optional = true }
 # cannot be out of step with bevy_rand due to dependencies on traits
 # and implementations between the two crates.
 [target.'cfg(any())'.dependencies]
-bevy_prng = { path = "bevy_prng", version = "=0.11" }
+bevy_prng = { path = "bevy_prng", version = "=0.10" }
 
 [dev-dependencies]
 bevy_app = { git = "https://github.com/bevyengine/bevy", package = "bevy_app", default-features = false, features = [
@@ -78,7 +78,7 @@ bevy_ecs = { git = "https://github.com/bevyengine/bevy", package = "bevy_ecs", d
     "multi_threaded",
     "async_executor",
 ] }
-bevy_prng = { path = "bevy_prng", version = "0.11", features = ["rand_chacha", "wyrand"] }
+bevy_prng = { path = "bevy_prng", version = "0.10", features = ["rand_chacha", "wyrand"] }
 rand = "0.8"
 ron = { version = "0.8.0", features = ["integer128"] }
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -59,3 +59,13 @@ struct Source;
         ));
 }
 ```
+
+## Migrating from v0.10 to v0.11
+
+To begin with, the `experimental` feature no longer does anything, as the observers/commands API is now exposed by default. The feature hasn't been removed, as it may be used for future experimental APIs.
+
+`GlobalSource` and `GlobalSeed` have been removed and now is represented by a `GlobalRngEntity` SystemParam. All uses of `GlobalSource` & `GlobalSeed` can be replaced by `GlobalRngEntity`.
+
+Various observer events have been removed and replaced with Bevy's relations APIs. `LinkRngSourceToTarget`, `ReseedRng`, `RngChildren` and `RngParent` no longer exist. Instead, for queries, `RngLinks` and `RngSource` are the relations components, and `SeedFromGlobal`, `SeedFromSource`, and `SeedLinked` are the new observer events. For the most part, it is recommended to use the new Commands APIs provided by `RngCommandsExt` & `RngEntityCommandsExt`.
+
+To enable the full relations API and features, make sure to add the `EntropyObserversPlugin` to your bevy app.

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -60,7 +60,7 @@ struct Source;
 }
 ```
 
-## Migrating from v0.10 to v0.11
+## Migrating from v0.9 to v0.10
 
 To begin with, the `experimental` feature no longer does anything, as the observers/commands API is now exposed by default. The feature hasn't been removed, as it may be used for future experimental APIs.
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -68,4 +68,4 @@ To begin with, the `experimental` feature no longer does anything, as the observ
 
 Various observer events have been removed and replaced with Bevy's relations APIs. `LinkRngSourceToTarget`, `ReseedRng`, `RngChildren` and `RngParent` no longer exist. Instead, for queries, `RngLinks` and `RngSource` are the relations components, and `SeedFromGlobal`, `SeedFromSource`, and `SeedLinked` are the new observer events. For the most part, it is recommended to use the new Commands APIs provided by `RngCommandsExt` & `RngEntityCommandsExt`.
 
-To enable the full relations API and features, make sure to add the `EntropyObserversPlugin` to your bevy app.
+To enable the full relations API and features, make sure to add the `EntropyRelationsPlugin` to your bevy app.

--- a/bevy_prng/src/chacha.rs
+++ b/bevy_prng/src/chacha.rs
@@ -1,4 +1,4 @@
-use crate::{newtype::newtype_prng, EntropySource};
+use crate::{EntropySource, newtype::newtype_prng};
 
 use bevy_reflect::{Reflect, ReflectFromReflect};
 use rand_core::{RngCore, SeedableRng};

--- a/bevy_prng/src/lib.rs
+++ b/bevy_prng/src/lib.rs
@@ -75,18 +75,18 @@ pub trait EntropySeed:
 
 #[cfg(feature = "serialize")]
 impl<
-        T: Debug
-            + Default
-            + PartialEq
-            + AsMut<[u8]>
-            + Clone
-            + Sync
-            + Send
-            + Reflectable
-            + FromReflect
-            + Serialize
-            + for<'a> Deserialize<'a>,
-    > EntropySeed for T
+    T: Debug
+        + Default
+        + PartialEq
+        + AsMut<[u8]>
+        + Clone
+        + Sync
+        + Send
+        + Reflectable
+        + FromReflect
+        + Serialize
+        + for<'a> Deserialize<'a>,
+> EntropySeed for T
 {
 }
 
@@ -116,9 +116,8 @@ pub trait EntropySeed:
 }
 
 #[cfg(not(feature = "serialize"))]
-impl<
-        T: Debug + Default + PartialEq + AsMut<[u8]> + Clone + Sync + Send + Reflectable + FromReflect,
-    > EntropySeed for T
+impl<T: Debug + Default + PartialEq + AsMut<[u8]> + Clone + Sync + Send + Reflectable + FromReflect>
+    EntropySeed for T
 {
 }
 

--- a/bevy_prng/src/pcg.rs
+++ b/bevy_prng/src/pcg.rs
@@ -1,4 +1,4 @@
-use crate::{newtype::newtype_prng, EntropySource};
+use crate::{EntropySource, newtype::newtype_prng};
 
 use bevy_reflect::{Reflect, ReflectFromReflect};
 use rand_core::{RngCore, SeedableRng};

--- a/bevy_prng/src/wyrand.rs
+++ b/bevy_prng/src/wyrand.rs
@@ -1,4 +1,4 @@
-use crate::{newtype::newtype_prng, EntropySource};
+use crate::{EntropySource, newtype::newtype_prng};
 
 use bevy_reflect::{Reflect, ReflectFromReflect};
 use rand_core::{RngCore, SeedableRng};

--- a/bevy_prng/src/xoshiro.rs
+++ b/bevy_prng/src/xoshiro.rs
@@ -1,9 +1,9 @@
 use crate::{
-    newtype::{newtype_prng, newtype_prng_remote},
     EntropySource,
+    newtype::{newtype_prng, newtype_prng_remote},
 };
 
-use bevy_reflect::{reflect_remote, std_traits::ReflectDefault, Reflect, ReflectFromReflect};
+use bevy_reflect::{Reflect, ReflectFromReflect, reflect_remote, std_traits::ReflectDefault};
 use rand_core::{RngCore, SeedableRng};
 
 #[cfg(feature = "serialize")]

--- a/examples/turn_based_game.rs
+++ b/examples/turn_based_game.rs
@@ -104,7 +104,7 @@ fn determine_attack_order(
     // RNG instance with a chosen seed.
     let mut entities: Vec<_> = q_entities
         .iter_mut()
-        .map(|mut entity| (entity.1.gen::<u32>(), entity))
+        .map(|mut entity| (entity.1.r#gen::<u32>(), entity))
         .collect();
 
     entities.sort_by_key(|k| k.0);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -57,7 +57,13 @@ impl<Rng: EntropySource> EntityRngCommands<'_, Rng> {
     /// Links a list of target [`Entity`]s to the current `Rng`, designating it
     /// as the Source `Rng` for the Targets to draw new seeds from.
     pub fn link_target_rngs(&mut self, targets: &[Entity]) -> &mut Self {
-        self.commands.add_related::<RngSource<Rng>>(targets);
+        self.commands.add_related::<RngSource<Rng, Rng>>(targets);
+
+        self
+    }
+
+    pub fn link_target_rngs_as<Target: EntropySource>(&mut self, targets: &[Entity]) -> &mut Self {
+        self.commands.add_related::<RngSource<Rng, Target>>(targets);
 
         self
     }
@@ -65,7 +71,13 @@ impl<Rng: EntropySource> EntityRngCommands<'_, Rng> {
     /// Emits an event for the current Source `Rng` to generate and push out new seeds to
     /// all linked target `Rng`s.
     pub fn reseed_linked(&mut self) -> &mut Self {
-        self.commands.trigger(SeedLinked::<Rng>::default());
+        self.commands.trigger(SeedLinked::<Rng, Rng>::default());
+
+        self
+    }
+
+    pub fn reseed_linked_as<Target: EntropySource>(&mut self) -> &mut Self {
+        self.commands.trigger(SeedLinked::<Rng, Target>::default());
 
         self
     }
@@ -73,18 +85,32 @@ impl<Rng: EntropySource> EntityRngCommands<'_, Rng> {
     /// Emits an event for the current `Rng` to pull a new seed from its linked
     /// Source `Rng`.
     pub fn reseed_from_source(&mut self) -> &mut Self {
-        self.commands.trigger(SeedFromSource::<Rng>::default());
+        self.commands.trigger(SeedFromSource::<Rng, Rng>::default());
+
+        self
+    }
+
+    pub fn reseed_from_source_as<Source: EntropySource>(&mut self) -> &mut Self {
+        self.commands.trigger(SeedFromSource::<Source, Rng>::default());
 
         self
     }
 
     /// Emits an event for the current `Rng` to pull a new seed from the
     /// Global `Rng`.
-    pub fn reseed_from_global(&mut self) -> &mut Self {
-        self.commands.trigger(SeedFromGlobal::<Rng>::default());
+    pub fn reseed_from_global<Source: EntropySource>(&mut self) -> &mut Self {
+        self.commands.trigger(SeedFromGlobal::<Source, Rng>::default());
 
         self
     }
+
+    // /// Emits an event for the current `Rng` to pull a new seed from the
+    // /// Global `Rng`.
+    // pub fn reseed_from_global<Source: EntropySource>(&mut self) -> &mut Self {
+    //     self.commands.trigger(SeedFromGlobal::<Source, Rng>::default());
+
+    //     self
+    // }
 
     /// Returns the inner [`EntityCommands`] with a smaller lifetime.
     pub fn entity_commands(&mut self) -> EntityCommands<'_> {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -43,7 +43,7 @@ impl<'a, Rng: EntropySource> Deref for RngEntityCommands<'a, Rng> {
     }
 }
 
-impl<'a, Rng: EntropySource> DerefMut for RngEntityCommands<'a, Rng> {
+impl<Rng: EntropySource> DerefMut for RngEntityCommands<'_, Rng> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.commands
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,11 @@ use bevy_ecs::{
 };
 use bevy_prng::EntropySource;
 
-use crate::observers::{RngSource, SeedFromGlobal, SeedFromSource, SeedLinked};
+use crate::{
+    observers::{RngSource, SeedFromGlobal, SeedFromSource, SeedLinked},
+    seed::RngSeed,
+    traits::SeedSource,
+};
 
 /// Commands for handling RNG specific operations with regards to seeding and
 /// linking.
@@ -30,33 +34,52 @@ impl RngCommandsExt for Commands<'_, '_> {
     }
 }
 
+impl<Rng: EntropySource> EntityRngCommands<'_, Rng>
+where
+    Rng::Seed: Send + Sync + Clone,
+{
+    /// Reseeds the current `Rng` with a provided seed value.
+    pub fn reseed(&mut self, seed: Rng::Seed) -> &mut Self {
+        self.commands.insert(RngSeed::<Rng>::from_seed(seed));
+
+        self
+    }
+
+    /// Reseeds the current `Rng` with a new seed drawn from OS or userspace entropy sources.
+    pub fn reseed_from_entropy(&mut self) -> &mut Self {
+        self.commands.insert(RngSeed::<Rng>::from_entropy());
+
+        self
+    }
+}
+
 impl<Rng: EntropySource> EntityRngCommands<'_, Rng> {
-    /// Links a list of target [`Entity`]s to the current Rng, designating it
-    /// as the Source Rng for the Targets to draw new seeds from.
+    /// Links a list of target [`Entity`]s to the current `Rng`, designating it
+    /// as the Source `Rng` for the Targets to draw new seeds from.
     pub fn link_target_rngs(&mut self, targets: &[Entity]) -> &mut Self {
         self.commands.add_related::<RngSource<Rng>>(targets);
 
         self
     }
 
-    /// Emits an event for the current Source Rng to push out new seeds to
-    /// all linked target Rngs.
+    /// Emits an event for the current Source `Rng` to generate and push out new seeds to
+    /// all linked target `Rng`s.
     pub fn reseed_linked(&mut self) -> &mut Self {
         self.commands.trigger(SeedLinked::<Rng>::default());
 
         self
     }
 
-    /// Emits an event for the current Rng to pull a new seed from its linked
-    /// Source Rng.
+    /// Emits an event for the current `Rng` to pull a new seed from its linked
+    /// Source `Rng`.
     pub fn reseed_from_source(&mut self) -> &mut Self {
         self.commands.trigger(SeedFromSource::<Rng>::default());
 
         self
     }
 
-    /// Emits an event for the current Rng to pull a new seed from the
-    /// Global Rng.
+    /// Emits an event for the current `Rng` to pull a new seed from the
+    /// Global `Rng`.
     pub fn reseed_from_global(&mut self) -> &mut Self {
         self.commands.trigger(SeedFromGlobal::<Rng>::default());
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,61 @@
+use core::marker::PhantomData;
+
+use bevy_ecs::{
+    entity::Entity,
+    system::{Commands, EntityCommands},
+};
+use bevy_prng::EntropySource;
+
+use crate::observers::{RngParent, SeedChildren, SeedFromGlobal, SeedFromParent};
+
+pub struct EntityRngCommands<'a, Rng: EntropySource> {
+    commands: EntityCommands<'a>,
+    _rng: PhantomData<Rng>,
+}
+
+pub trait RngCommandsExt {
+    fn rng<Rng: EntropySource>(&mut self, entity: Entity) -> EntityRngCommands<'_, Rng>;
+}
+
+impl RngCommandsExt for Commands<'_, '_> {
+    fn rng<Rng: EntropySource>(&mut self, entity: Entity) -> EntityRngCommands<'_, Rng> {
+        EntityRngCommands {
+            commands: self.entity(entity),
+            _rng: PhantomData,
+        }
+    }
+}
+
+impl<Rng: EntropySource> EntityRngCommands<'_, Rng> {
+    pub fn link_target_rngs(&mut self, targets: &[Entity]) -> &mut Self {
+        self.commands.add_related::<RngParent<Rng>>(targets);
+
+        self
+    }
+
+    pub fn reseed_linked(&mut self) -> &mut Self {
+        self.commands.trigger(SeedChildren::<Rng>::default());
+
+        self
+    }
+
+    pub fn reseed_from_source(&mut self) -> &mut Self {
+        self.commands.trigger(SeedFromParent::<Rng>::default());
+
+        self
+    }
+
+    pub fn reseed_from_global(&mut self) -> &mut Self {
+        self.commands.trigger(SeedFromGlobal::<Rng>::default());
+
+        self
+    }
+
+    pub fn entity_commands(&mut self) -> EntityCommands<'_> {
+        self.commands.reborrow()
+    }
+
+    pub fn commands(&mut self) -> Commands<'_, '_> {
+        self.commands.commands()
+    }
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,14 +6,18 @@ use bevy_ecs::{
 };
 use bevy_prng::EntropySource;
 
-use crate::observers::{RngParent, SeedChildren, SeedFromGlobal, SeedFromParent};
+use crate::observers::{RngSource, SeedFromGlobal, SeedFromSource, SeedLinked};
 
+/// Commands for handling RNG specific operations with regards to seeding and
+/// linking.
 pub struct EntityRngCommands<'a, Rng: EntropySource> {
     commands: EntityCommands<'a>,
     _rng: PhantomData<Rng>,
 }
 
+/// Extension trait for [`Commands`] for getting access to [`EntityRngCommands`].
 pub trait RngCommandsExt {
+    /// Takes an [`Entity`] and yields the [`EntityRngCommands`] for that entity.
     fn rng<Rng: EntropySource>(&mut self, entity: Entity) -> EntityRngCommands<'_, Rng>;
 }
 
@@ -27,34 +31,44 @@ impl RngCommandsExt for Commands<'_, '_> {
 }
 
 impl<Rng: EntropySource> EntityRngCommands<'_, Rng> {
+    /// Links a list of target [`Entity`]s to the current Rng, designating it
+    /// as the Source Rng for the Targets to draw new seeds from.
     pub fn link_target_rngs(&mut self, targets: &[Entity]) -> &mut Self {
-        self.commands.add_related::<RngParent<Rng>>(targets);
+        self.commands.add_related::<RngSource<Rng>>(targets);
 
         self
     }
 
+    /// Emits an event for the current Source Rng to push out new seeds to
+    /// all linked target Rngs.
     pub fn reseed_linked(&mut self) -> &mut Self {
-        self.commands.trigger(SeedChildren::<Rng>::default());
+        self.commands.trigger(SeedLinked::<Rng>::default());
 
         self
     }
 
+    /// Emits an event for the current Rng to pull a new seed from its linked
+    /// Source Rng.
     pub fn reseed_from_source(&mut self) -> &mut Self {
-        self.commands.trigger(SeedFromParent::<Rng>::default());
+        self.commands.trigger(SeedFromSource::<Rng>::default());
 
         self
     }
 
+    /// Emits an event for the current Rng to pull a new seed from the
+    /// Global Rng.
     pub fn reseed_from_global(&mut self) -> &mut Self {
         self.commands.trigger(SeedFromGlobal::<Rng>::default());
 
         self
     }
 
+    /// Returns the inner [`EntityCommands`] with a smaller lifetime.
     pub fn entity_commands(&mut self) -> EntityCommands<'_> {
         self.commands.reborrow()
     }
 
+    /// Returns the underlying [`Commands`].
     pub fn commands(&mut self) -> Commands<'_, '_> {
         self.commands.commands()
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,8 @@
-use core::{fmt::Debug, marker::PhantomData, ops::{Deref, DerefMut}};
+use core::{
+    fmt::Debug,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
 use bevy_ecs::{
     entity::Entity,
@@ -52,15 +56,22 @@ impl<Rng: EntropySource> DerefMut for RngEntityCommands<'_, Rng> {
 /// Extension trait to create a [`RngEntityCommands`] directly from a [`Commands`].
 pub trait RngCommandsExt {
     /// Creates a [`RngEntityCommands`] from a given [`Entity`].
-    fn rng<Rng: EntropySource>(&mut self, entity: &RngEntityItem<'_, Rng>) -> RngEntityCommands<'_, Rng>
+    fn rng<Rng: EntropySource>(
+        &mut self,
+        entity: &RngEntityItem<'_, Rng>,
+    ) -> RngEntityCommands<'_, Rng>
     where
         Rng::Seed: Debug + Clone + Send + Sync;
 }
 
 impl RngCommandsExt for Commands<'_, '_> {
-    fn rng<Rng: EntropySource>(&mut self, entity: &RngEntityItem<'_, Rng>) -> RngEntityCommands<'_, Rng>
-        where
-            Rng::Seed: Debug + Clone + Send + Sync {
+    fn rng<Rng: EntropySource>(
+        &mut self,
+        entity: &RngEntityItem<'_, Rng>,
+    ) -> RngEntityCommands<'_, Rng>
+    where
+        Rng::Seed: Debug + Clone + Send + Sync,
+    {
         self.entity(entity.entity()).rng()
     }
 }
@@ -121,8 +132,7 @@ impl<Rng: EntropySource> RngEntityCommands<'_, Rng> {
     /// Source `Rng`. This method assumes the `Source` and `Target` are the same `Rng`
     /// type.
     pub fn reseed_from_source(&mut self) -> &mut Self {
-        self.commands
-            .trigger(SeedFromSource::<Rng, Rng>::default());
+        self.commands.trigger(SeedFromSource::<Rng, Rng>::default());
 
         self
     }
@@ -141,8 +151,7 @@ impl<Rng: EntropySource> RngEntityCommands<'_, Rng> {
     /// Emits an event for the current `Rng` to pull a new seed from the specified
     /// Global `Rng`.
     pub fn reseed_from_global(&mut self) -> &mut Self {
-        self.commands
-            .trigger(SeedFromGlobal::<Rng, Rng>::default());
+        self.commands.trigger(SeedFromGlobal::<Rng, Rng>::default());
 
         self
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -76,10 +76,11 @@ pub trait RngCommandsExt {
     /// ```
     /// use bevy_ecs::prelude::*;
     /// use bevy_rand::prelude::*;
-    /// 
+    /// use bevy_prng::WyRand;
+    ///
     /// #[derive(Component)]
     /// struct Source;
-    /// 
+    ///
     /// fn reseed(mut commands: Commands, query: Query<RngEntity<WyRand>, With<Source>>) {
     ///     for entity in &query {
     ///         commands.rng_entity(&entity).reseed_linked();
@@ -131,6 +132,29 @@ where
 impl<Rng: EntropySource> RngEntityCommands<'_, Rng> {
     /// Spawns entities related to the current `Source` Rng, linking them and then seeding
     /// them automatically.
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    /// use bevy_rand::prelude::*;
+    /// use bevy_prng::WyRand;
+    ///
+    /// #[derive(Component)]
+    /// struct Source;
+    /// #[derive(Component)]
+    /// struct Target;
+    ///
+    /// fn setup_rng_sources(mut global: GlobalRngEntity<WyRand>) {
+    ///     global.rng_commands().with_target_rngs([(
+    ///     Source,
+    ///     RngLinks::<WyRand, WyRand>::spawn((
+    ///         Spawn(Target),
+    ///         Spawn(Target),
+    ///         Spawn(Target),
+    ///         Spawn(Target),
+    ///         Spawn(Target),
+    ///     )),
+    /// )]);
+    /// }
+    /// ```
     #[inline]
     pub fn with_target_rngs(
         &mut self,
@@ -141,6 +165,30 @@ impl<Rng: EntropySource> RngEntityCommands<'_, Rng> {
 
     /// Spawns entities related to the current Source Rng, linking them and then seeding
     /// them automatically with the specified `Target` Rng.
+    ///
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    /// use bevy_rand::prelude::*;
+    /// use bevy_prng::{ChaCha8Rng, WyRand};
+    ///
+    /// #[derive(Component)]
+    /// struct Source;
+    /// #[derive(Component)]
+    /// struct Target;
+    ///
+    /// fn setup_rng_sources(mut global: GlobalRngEntity<ChaCha8Rng>) {
+    ///     global.rng_commands().with_target_rngs_as::<WyRand>([(
+    ///         Source,
+    ///         RngLinks::<WyRand, WyRand>::spawn((
+    ///             Spawn(Target),
+    ///             Spawn(Target),
+    ///             Spawn(Target),
+    ///             Spawn(Target),
+    ///             Spawn(Target),
+    ///         )),
+    ///     )]);
+    /// }
+    /// ```
     #[inline]
     pub fn with_target_rngs_as<Target: EntropySource>(
         &mut self,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -26,9 +26,9 @@ pub struct RngEntityCommands<'a, Rng: EntropySource> {
     _rng: PhantomData<Rng>,
 }
 
-/// Extension trait for [`Commands`] for getting access to [`EntityRngCommands`].
+/// Extension trait for [`Commands`] for getting access to [`RngEntityCommands`].
 pub trait RngEntityCommandsExt<'a> {
-    /// Takes an [`Entity`] and yields the [`EntityRngCommands`] for that entity.
+    /// Takes an [`Entity`] and yields the [`RngEntityCommands`] for that entity.
     fn rng<Rng: EntropySource>(self) -> RngEntityCommands<'a, Rng>;
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -29,6 +29,20 @@ pub struct RngEntityCommands<'a, Rng: EntropySource> {
 /// Extension trait for [`Commands`] for getting access to [`RngEntityCommands`].
 pub trait RngEntityCommandsExt<'a> {
     /// Takes an [`Entity`] and yields the [`RngEntityCommands`] for that entity.
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    /// use bevy_prng::WyRand;
+    /// use bevy_rand::prelude::*;
+    ///
+    /// #[derive(Component)]
+    /// struct Target;
+    ///
+    /// fn intialise_rng_entities(mut commands: Commands, mut q_targets: Query<Entity, With<Target>>) {
+    ///     for target in &q_targets {
+    ///         commands.entity(target).rng::<WyRand>().reseed_from_entropy();
+    ///     }
+    /// }
+    /// ```
     fn rng<Rng: EntropySource>(self) -> RngEntityCommands<'a, Rng>;
 }
 
@@ -59,7 +73,20 @@ impl<Rng: EntropySource> DerefMut for RngEntityCommands<'_, Rng> {
 /// Extension trait to create a [`RngEntityCommands`] directly from a [`Commands`].
 pub trait RngCommandsExt {
     /// Creates a [`RngEntityCommands`] from a given [`Entity`].
-    fn rng<Rng: EntropySource>(
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    /// use bevy_rand::prelude::*;
+    /// 
+    /// #[derive(Component)]
+    /// struct Source;
+    /// 
+    /// fn reseed(mut commands: Commands, query: Query<RngEntity<WyRand>, With<Source>>) {
+    ///     for entity in &query {
+    ///         commands.rng_entity(&entity).reseed_linked();
+    ///     }
+    /// }
+    /// ```
+    fn rng_entity<Rng: EntropySource>(
         &mut self,
         entity: &RngEntityItem<'_, Rng>,
     ) -> RngEntityCommands<'_, Rng>
@@ -69,7 +96,7 @@ pub trait RngCommandsExt {
 
 impl RngCommandsExt for Commands<'_, '_> {
     #[inline]
-    fn rng<Rng: EntropySource>(
+    fn rng_entity<Rng: EntropySource>(
         &mut self,
         entity: &RngEntityItem<'_, Rng>,
     ) -> RngEntityCommands<'_, Rng>

--- a/src/component.rs
+++ b/src/component.rs
@@ -241,7 +241,7 @@ where
 mod tests {
     use alloc::format;
 
-    use bevy_prng::{ChaCha12Rng, ChaCha8Rng};
+    use bevy_prng::{ChaCha8Rng, ChaCha12Rng};
     use bevy_reflect::TypePath;
 
     use super::*;
@@ -296,8 +296,8 @@ mod tests {
     #[test]
     fn rng_untyped_serialization() {
         use bevy_reflect::{
-            serde::{ReflectDeserializer, ReflectSerializer},
             FromReflect, TypeRegistry,
+            serde::{ReflectDeserializer, ReflectSerializer},
         };
         use ron::to_string;
         use serde::de::DeserializeSeed;
@@ -344,8 +344,8 @@ mod tests {
     #[test]
     fn rng_typed_serialization() {
         use bevy_reflect::{
-            serde::{TypedReflectDeserializer, TypedReflectSerializer},
             FromReflect, GetTypeRegistration, TypeRegistry,
+            serde::{TypedReflectDeserializer, TypedReflectSerializer},
         };
         use ron::ser::to_string;
         use serde::de::DeserializeSeed;

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,19 +1,9 @@
-use core::fmt::Debug;
-use core::marker::PhantomData;
+use core::{fmt::Debug, ops::Deref};
 
-use bevy_ecs::{
-    component::Component,
-    entity::Entity,
-    query::{QueryData, ReadOnlyQueryData, With},
-    system::{Commands, Single, SystemParam},
-    world::Mut,
-};
+use bevy_ecs::{component::Component, query::With, system::{Commands, Single, SystemParam}};
 use bevy_prng::EntropySource;
 
-use crate::{
-    prelude::{EntityRngCommands, Entropy, RngCommandsExt},
-    seed::RngSeed,
-};
+use crate::{params::{RngEntity, RngEntityItem}, prelude::{Entropy, RngEntityCommands, RngEntityCommandsExt}};
 
 /// A marker component to signify a global source. Warning: there should only be **one** entity per
 /// PRNG type that qualifies as the `Global` source.
@@ -24,67 +14,35 @@ pub struct Global;
 /// [`Entropy`] component to generate new random numbers from.
 pub type GlobalEntropy<'w, T> = Single<'w, &'static mut Entropy<T>, With<Global>>;
 
-/// A helper query to yield the [`Global`] source for a given [`EntropySource`]. This returns the
-/// [`RngSeed`] component to allow inspection to the initial seed for the source.
-pub type GlobalSeed<'w, T> = Single<'w, &'static RngSeed<T>, With<Global>>;
-
-/// A helper query to yield the [`Global`] source for a given [`EntropySource`]. This returns the
-/// [`Entity`] id to modify the source with via commands.
-pub type GlobalSource<'w, T> = Single<'w, Entity, (With<RngSeed<T>>, With<Global>)>;
-
-#[derive(Debug, QueryData)]
-#[query_data(mutable)]
-pub struct RngData<Rng: EntropySource>
-where
-    Rng::Seed: Debug + Send + Sync + Clone,
-{
-    entropy: &'static mut Entropy<Rng>,
-    seed: &'static RngSeed<Rng>,
-    entity: Entity,
-}
-
-impl<Rng: EntropySource> RngDataReadOnlyItem<'_, Rng>
-where
-    Rng::Seed: Debug + Send + Sync + Clone,
-{
-    fn entity(&self) -> Entity {
-        self.entity
-    }
-
-    fn seed(&self) -> &RngSeed<Rng> {
-        self.seed
-    }
-}
-
-impl<'a, Rng: EntropySource> RngDataItem<'a, Rng>
-where
-    Rng::Seed: Debug + Send + Sync + Clone,
-{
-    fn entropy(&mut self) -> &mut Entropy<Rng> {
-        self.entropy.as_mut()
-    }
-
-    fn rng_commands(&self, commands: &'a mut Commands) -> EntityRngCommands<'_, Rng>
-    {
-        commands.rng(self.entity)
-    }
-}
-
+/// A helper [`SystemParam`] to obtain the [`Global`] entity & seed of a given `Rng`. This yields
+/// read-only access to the global entity and its seed, and also allows constructing a
+/// [`RngEntityCommands`] directly from it.
 #[derive(SystemParam)]
-pub struct GlobalRng<'w, 's, Rng: EntropySource>
+pub struct GlobalRngEntity<'w, 's, Rng: EntropySource>
 where
-    Rng::Seed: Debug + Send + Sync + Clone,
+    Rng::Seed: Debug + Clone + Send + Sync,
 {
     commands: Commands<'w, 's>,
-    data: Single<'w, RngData<Rng>, With<Global>>,
-    _source: PhantomData<Rng>,
+    data: Single<'w, RngEntity<Rng>, With<Global>>,
 }
 
-impl<Rng: EntropySource> GlobalRng<'_, '_, Rng>
+impl<Rng: EntropySource> GlobalRngEntity<'_, '_, Rng>
 where
     Rng::Seed: Debug + Send + Sync + Clone,
 {
-    pub fn rng_commands(&mut self) -> EntityRngCommands<'_, Rng> {
-        self.commands.rng(self.data.entity)
+    /// Creates a [`Global`]'s [`RngEntityCommands`].
+    pub fn rng_commands(&mut self) -> RngEntityCommands<'_, Rng> {
+        self.commands.entity(self.data.entity()).rng()
+    }
+}
+
+impl<'w, Rng: EntropySource> Deref for GlobalRngEntity<'w, '_, Rng>
+where
+    Rng::Seed: Debug + Clone + Send + Sync,
+{
+    type Target = RngEntityItem<'w, Rng>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
     }
 }

--- a/src/global.rs
+++ b/src/global.rs
@@ -24,6 +24,15 @@ pub type GlobalEntropy<'w, T> = Single<'w, &'static mut Entropy<T>, With<Global>
 /// A helper [`SystemParam`] to obtain the [`Global`] entity & seed of a given `Rng`. This yields
 /// read-only access to the global entity and its seed, and also allows constructing a
 /// [`RngEntityCommands`] directly from it.
+/// ```
+/// use bevy_ecs::prelude::*;
+/// use bevy_rand::prelude::*;
+/// use bevy_prng::WyRand;
+/// 
+/// fn reseed_all_linked_rngs_from_global(mut global: GlobalRngEntity<WyRand>) {
+///     global.rng_commands().reseed_linked();
+/// }
+/// ```
 #[derive(SystemParam)]
 pub struct GlobalRngEntity<'w, 's, Rng: EntropySource>
 where

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,9 +1,16 @@
 use core::{fmt::Debug, ops::Deref};
 
-use bevy_ecs::{component::Component, query::With, system::{Commands, Single, SystemParam}};
+use bevy_ecs::{
+    component::Component,
+    query::With,
+    system::{Commands, Single, SystemParam},
+};
 use bevy_prng::EntropySource;
 
-use crate::{params::{RngEntity, RngEntityItem}, prelude::{Entropy, RngEntityCommands, RngEntityCommandsExt}};
+use crate::{
+    params::{RngEntity, RngEntityItem},
+    prelude::{Entropy, RngEntityCommands, RngEntityCommandsExt},
+};
 
 /// A marker component to signify a global source. Warning: there should only be **one** entity per
 /// PRNG type that qualifies as the `Global` source.

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,6 +1,19 @@
-use bevy_ecs::{component::Component, entity::Entity, query::With, system::Single};
+use core::fmt::Debug;
+use core::marker::PhantomData;
 
-use crate::{prelude::Entropy, seed::RngSeed};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    query::{QueryData, ReadOnlyQueryData, With},
+    system::{Commands, Single, SystemParam},
+    world::Mut,
+};
+use bevy_prng::EntropySource;
+
+use crate::{
+    prelude::{EntityRngCommands, Entropy, RngCommandsExt},
+    seed::RngSeed,
+};
 
 /// A marker component to signify a global source. Warning: there should only be **one** entity per
 /// PRNG type that qualifies as the `Global` source.
@@ -18,3 +31,60 @@ pub type GlobalSeed<'w, T> = Single<'w, &'static RngSeed<T>, With<Global>>;
 /// A helper query to yield the [`Global`] source for a given [`EntropySource`]. This returns the
 /// [`Entity`] id to modify the source with via commands.
 pub type GlobalSource<'w, T> = Single<'w, Entity, (With<RngSeed<T>>, With<Global>)>;
+
+#[derive(Debug, QueryData)]
+#[query_data(mutable)]
+pub struct RngData<Rng: EntropySource>
+where
+    Rng::Seed: Debug + Send + Sync + Clone,
+{
+    entropy: &'static mut Entropy<Rng>,
+    seed: &'static RngSeed<Rng>,
+    entity: Entity,
+}
+
+impl<Rng: EntropySource> RngDataReadOnlyItem<'_, Rng>
+where
+    Rng::Seed: Debug + Send + Sync + Clone,
+{
+    fn entity(&self) -> Entity {
+        self.entity
+    }
+
+    fn seed(&self) -> &RngSeed<Rng> {
+        self.seed
+    }
+}
+
+impl<'a, Rng: EntropySource> RngDataItem<'a, Rng>
+where
+    Rng::Seed: Debug + Send + Sync + Clone,
+{
+    fn entropy(&mut self) -> &mut Entropy<Rng> {
+        self.entropy.as_mut()
+    }
+
+    fn rng_commands(&self, commands: &'a mut Commands) -> EntityRngCommands<'_, Rng>
+    {
+        commands.rng(self.entity)
+    }
+}
+
+#[derive(SystemParam)]
+pub struct GlobalRng<'w, 's, Rng: EntropySource>
+where
+    Rng::Seed: Debug + Send + Sync + Clone,
+{
+    commands: Commands<'w, 's>,
+    data: Single<'w, RngData<Rng>, With<Global>>,
+    _source: PhantomData<Rng>,
+}
+
+impl<Rng: EntropySource> GlobalRng<'_, '_, Rng>
+where
+    Rng::Seed: Debug + Send + Sync + Clone,
+{
+    pub fn rng_commands(&mut self) -> EntityRngCommands<'_, Rng> {
+        self.commands.rng(self.data.entity)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,12 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+/// Command extensions for relating groups of RNGs.
+pub mod commands;
 /// Components for integrating [`RngCore`] PRNGs into bevy. Must be newtyped to support [`Reflect`].
 pub mod component;
 /// Global [`crate::component::Entropy`] sources, with query helpers.
 pub mod global;
-#[cfg(feature = "experimental")]
 /// Utility observers for handling seeding between parent/child entropy sources
 pub mod observers;
 /// Plugin for integrating [`RngCore`] PRNGs into bevy. Must be newtyped to support [`Reflect`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub mod component;
 pub mod global;
 /// Utility observers for handling seeding between parent/child entropy sources
 pub mod observers;
+/// Utility query/system parameters for accessing RNGs.
+pub mod params;
 /// Plugin for integrating [`RngCore`] PRNGs into bevy. Must be newtyped to support [`Reflect`].
 pub mod plugin;
 /// Prelude for providing all necessary types for easy use.

--- a/src/observers.rs
+++ b/src/observers.rs
@@ -22,7 +22,7 @@ pub struct RngLinks<Source, Target>(Vec<Entity>, PhantomData<Source>, PhantomDat
 impl<Source: EntropySource, Target: EntropySource> RelationshipTarget for RngLinks<Source, Target> {
     type Relationship = RngSource<Source, Target>;
     type Collection = Vec<Entity>;
-    const LINKED_SPAWN: bool = true;
+    const LINKED_SPAWN: bool = false;
 
     fn collection(&self) -> &Self::Collection {
         &self.0

--- a/src/observers.rs
+++ b/src/observers.rs
@@ -232,7 +232,7 @@ pub fn seed_children<Rng: EntropySource>(
             .map(|target| (target, rng.fork_seed()))
             .collect();
 
-        commands.try_insert_batch(batched);
+        commands.insert_batch(batched);
     }
 }
 
@@ -248,6 +248,7 @@ pub fn trigger_seed_children<Rng: EntropySource>(
     if trigger.target() == Entity::PLACEHOLDER {
         return;
     }
+
     // Check whether the triggered entity is a source entity. If not, do nothing otherwise we
     // will keep triggering and cause a stack overflow.
     if let Ok(source) = q_source.get(trigger.target()) {

--- a/src/observers.rs
+++ b/src/observers.rs
@@ -221,9 +221,6 @@ pub fn seed_children<Rng: EntropySource>(
 ) where
     Rng::Seed: Send + Sync + Clone,
 {
-    if trigger.target() == Entity::PLACEHOLDER {
-        return;
-    }
     if let Ok((mut rng, targets)) = q_source.get_mut(trigger.target()) {
         let batched: Vec<_> = targets
             .0
@@ -245,10 +242,6 @@ pub fn trigger_seed_children<Rng: EntropySource>(
 ) where
     Rng::Seed: Send + Sync + Clone,
 {
-    if trigger.target() == Entity::PLACEHOLDER {
-        return;
-    }
-
     // Check whether the triggered entity is a source entity. If not, do nothing otherwise we
     // will keep triggering and cause a stack overflow.
     if let Ok(source) = q_source.get(trigger.target()) {

--- a/src/observers.rs
+++ b/src/observers.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     component::{ComponentHooks, Immutable, Mutable, StorageType},
     prelude::{Commands, Component, Entity, Event, OnInsert, Trigger, With},
     relationship::{Relationship, RelationshipTarget},
-    system::{Populated, Query},
+    system::Query,
 };
 
 use bevy_prng::EntropySource;
@@ -22,6 +22,7 @@ pub struct RngLinks<Source, Target>(Vec<Entity>, PhantomData<Source>, PhantomDat
 impl<Source: EntropySource, Target: EntropySource> RelationshipTarget for RngLinks<Source, Target> {
     type Relationship = RngSource<Source, Target>;
     type Collection = Vec<Entity>;
+    const LINKED_SPAWN: bool = true;
 
     fn collection(&self) -> &Self::Collection {
         &self.0
@@ -143,8 +144,8 @@ pub fn seed_from_global<Source: EntropySource, Target: EntropySource>(
 /// observer system will only run if there are parent entities to have seeds pulled from.
 pub fn seed_from_parent<Source: EntropySource, Target: EntropySource>(
     trigger: Trigger<SeedFromSource<Source, Target>>,
-    q_linked: Populated<&RngSource<Source, Target>>,
-    mut q_parents: Populated<&mut Entropy<Source>, With<RngLinks<Source, Target>>>,
+    q_linked: Query<&RngSource<Source, Target>>,
+    mut q_parents: Query<&mut Entropy<Source>, With<RngLinks<Source, Target>>>,
     mut commands: Commands,
 ) where
     Source::Seed: Send + Sync + Clone,

--- a/src/observers.rs
+++ b/src/observers.rs
@@ -197,6 +197,6 @@ pub fn trigger_seed_linked<Source: EntropySource, Target: EntropySource>(
     // Check whether the triggered entity is a source entity. If not, do nothing otherwise we
     // will keep triggering and cause a stack overflow.
     if let Ok(source) = q_source.get(trigger.target()) {
-        commands.rng(&source).reseed_linked_as::<Target>();
+        commands.rng_entity(&source).reseed_linked_as::<Target>();
     }
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -16,7 +16,7 @@ where
     entity: Entity,
 }
 
-impl<'w, Rng: EntropySource> RngEntityItem<'w, Rng>
+impl<Rng: EntropySource> RngEntityItem<'_, Rng>
 where
     Rng::Seed: Debug + Clone,
 {

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,0 +1,37 @@
+use core::fmt::Debug;
+
+use bevy_ecs::{entity::Entity, query::QueryData};
+use bevy_prng::EntropySource;
+
+use crate::{seed::RngSeed, traits::SeedSource};
+
+/// A smart query data wrapper that selects for entities that match the `Rng` type,
+/// returning read-only data for the seed and the entity.
+#[derive(Debug, QueryData)]
+pub struct RngEntity<Rng: EntropySource>
+where
+    Rng::Seed: Debug + Clone + Send + Sync,
+{
+    seed: &'static RngSeed<Rng>,
+    entity: Entity,
+}
+
+impl<'w, Rng: EntropySource> RngEntityItem<'w, Rng>
+where
+    Rng::Seed: Debug + Clone,
+{
+    /// Return the [`Entity`] of the data
+    pub fn entity(&self) -> Entity {
+        self.entity
+    }
+
+    /// Get a reference to the [`RngSeed`] component for the given data
+    pub fn seed(&self) -> &RngSeed<Rng> {
+        self.seed
+    }
+
+    /// Clone the seed from the data
+    pub fn clone_seed(&self) -> Rng::Seed {
+        self.seed.clone_seed()
+    }
+}

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -89,6 +89,9 @@ where
         {
             world.add_observer(crate::observers::seed_from_global::<R>);
             world.add_observer(crate::observers::reseed::<R>);
+            world.add_observer(crate::observers::seed_from_parent::<R>);
+            world.add_observer(crate::observers::seed_children::<R>);
+            world.add_observer(crate::observers::trigger_seed_children::<R>);
         }
 
         world.flush();
@@ -124,9 +127,6 @@ where
     Rng::Seed: Send + Sync + Clone,
 {
     fn build(&self, app: &mut App) {
-        app.add_observer(crate::observers::seed_from_parent::<Rng>)
-            .add_observer(crate::observers::seed_children::<Rng>)
-            .add_observer(crate::observers::link_targets::<Source, Target, Rng>)
-            .add_observer(crate::observers::trigger_seed_children::<Rng>);
+        app.add_observer(crate::observers::link_targets::<Source, Target, Rng>);
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,10 +1,5 @@
-#[cfg(feature = "experimental")]
-use std::marker::PhantomData;
-
 use crate::{component::Entropy, global::Global, seed::RngSeed, traits::SeedSource};
 use bevy_app::{App, Plugin};
-#[cfg(feature = "experimental")]
-use bevy_ecs::prelude::Component;
 use bevy_prng::{EntropySeed, EntropySource};
 
 /// Plugin for integrating a PRNG that implements `RngCore` into
@@ -85,48 +80,13 @@ where
             Global,
         ));
 
-        #[cfg(feature = "experimental")]
-        {
-            world.add_observer(crate::observers::seed_from_global::<R>);
-            world.add_observer(crate::observers::reseed::<R>);
-            world.add_observer(crate::observers::seed_from_parent::<R>);
-            world.add_observer(crate::observers::seed_children::<R>);
-            world.add_observer(crate::observers::trigger_seed_children::<R>);
-        }
+        world.add_observer(crate::observers::seed_from_global::<R>);
+        world.add_observer(crate::observers::reseed::<R>);
+        world.add_observer(crate::observers::seed_from_parent::<R>);
+        world.add_observer(crate::observers::seed_children::<R>);
+        world.add_observer(crate::observers::trigger_seed_children::<R>);
+        world.add_observer(crate::observers::link_targets::<R>);
 
         world.flush();
-    }
-}
-
-/// Plugin for setting up linked RNG sources
-#[cfg(feature = "experimental")]
-pub struct LinkedEntropySources<Source: Component, Target: Component, Rng: EntropySource + 'static>
-{
-    rng: PhantomData<Rng>,
-    source: PhantomData<Source>,
-    target: PhantomData<Target>,
-}
-
-#[cfg(feature = "experimental")]
-impl<Source: Component, Target: Component, Rng: EntropySource + 'static> Default
-    for LinkedEntropySources<Source, Target, Rng>
-{
-    fn default() -> Self {
-        Self {
-            rng: PhantomData,
-            source: PhantomData,
-            target: PhantomData,
-        }
-    }
-}
-
-#[cfg(feature = "experimental")]
-impl<Source: Component, Target: Component, Rng: EntropySource + 'static> Plugin
-    for LinkedEntropySources<Source, Target, Rng>
-where
-    Rng::Seed: Send + Sync + Clone,
-{
-    fn build(&self, app: &mut App) {
-        app.add_observer(crate::observers::link_targets::<Source, Target, Rng>);
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -125,7 +125,8 @@ where
 {
     fn build(&self, app: &mut App) {
         app.add_observer(crate::observers::seed_from_parent::<Rng>)
-            .add_observer(crate::observers::seed_children::<Source, Target, Rng>)
-            .add_observer(crate::observers::link_targets::<Source, Target, Rng>);
+            .add_observer(crate::observers::seed_children::<Rng>)
+            .add_observer(crate::observers::link_targets::<Source, Target, Rng>)
+            .add_observer(crate::observers::trigger_seed_children::<Rng>);
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -92,9 +92,14 @@ pub struct EntropyObserversPlugin<Source, Target> {
     _target: PhantomData<Target>,
 }
 
-impl<Source: EntropySource, Target: EntropySource> Default for EntropyObserversPlugin<Source, Target> {
+impl<Source: EntropySource, Target: EntropySource> Default
+    for EntropyObserversPlugin<Source, Target>
+{
     fn default() -> Self {
-        Self { _source: PhantomData, _target: PhantomData }
+        Self {
+            _source: PhantomData,
+            _target: PhantomData,
+        }
     }
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -82,33 +82,34 @@ where
             Global,
         ));
 
-        world.add_observer(crate::observers::seed_from_global::<Rng>);
-
         world.flush();
     }
 }
 
 /// [`Plugin`] for setting up observers for handling related Rngs.
-pub struct EntropyRelationPlugin<Rng: EntropySource> {
-    _rng: PhantomData<Rng>,
+pub struct EntropyObserversPlugin<Source, Target> {
+    _source: PhantomData<Source>,
+    _target: PhantomData<Target>,
 }
 
-impl<Rng: EntropySource> Default for EntropyRelationPlugin<Rng> {
+impl<Source: EntropySource, Target: EntropySource> Default for EntropyObserversPlugin<Source, Target> {
     fn default() -> Self {
-        Self { _rng: PhantomData }
+        Self { _source: PhantomData, _target: PhantomData }
     }
 }
 
-impl<Rng: EntropySource> Plugin for EntropyRelationPlugin<Rng>
+impl<Source: EntropySource, Target: EntropySource> Plugin for EntropyObserversPlugin<Source, Target>
 where
-    Rng::Seed: Send + Sync + Clone,
+    Source::Seed: Send + Sync + Clone,
+    Target::Seed: Send + Sync + Clone,
 {
     fn build(&self, app: &mut App) {
         let world = app.world_mut();
 
-        world.add_observer(crate::observers::seed_from_parent::<Rng>);
-        world.add_observer(crate::observers::seed_linked::<Rng>);
-        world.add_observer(crate::observers::trigger_seed_linked::<Rng>);
+        world.add_observer(crate::observers::seed_from_global::<Source, Target>);
+        world.add_observer(crate::observers::seed_from_parent::<Source, Target>);
+        world.add_observer(crate::observers::seed_linked::<Source, Target>);
+        world.add_observer(crate::observers::trigger_seed_linked::<Source, Target>);
 
         world.flush();
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,4 @@
+pub use crate::commands::{RngCommandsExt, EntityRngCommands};
 pub use crate::component::Entropy;
 pub use crate::global::{Global, GlobalEntropy, GlobalSeed, GlobalSource};
 pub use crate::plugin::EntropyPlugin;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use crate::commands::{RngCommandsExt, EntityRngCommands};
+pub use crate::commands::{EntityRngCommands, RngCommandsExt};
 pub use crate::component::Entropy;
 pub use crate::global::{Global, GlobalEntropy, GlobalSeed, GlobalSource};
 pub use crate::plugin::EntropyPlugin;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,8 +1,9 @@
-pub use crate::commands::{RngEntityCommands, RngCommandsExt, RngEntityCommandsExt};
+pub use crate::commands::{RngCommandsExt, RngEntityCommands, RngEntityCommandsExt};
 pub use crate::component::Entropy;
 pub use crate::global::{Global, GlobalEntropy, GlobalRngEntity};
+pub use crate::observers::{RngLinks, RngSource, SeedFromGlobal, SeedFromSource, SeedLinked};
 pub use crate::params::{RngEntity, RngEntityItem};
-pub use crate::plugin::EntropyPlugin;
+pub use crate::plugin::{EntropyObserversPlugin, EntropyPlugin};
 pub use crate::seed::RngSeed;
 pub use crate::traits::{
     ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableInnerSeed, ForkableRng, ForkableSeed,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,7 @@
-pub use crate::commands::{EntityRngCommands, RngCommandsExt};
+pub use crate::commands::{RngEntityCommands, RngCommandsExt, RngEntityCommandsExt};
 pub use crate::component::Entropy;
-pub use crate::global::{Global, GlobalEntropy, GlobalSeed, GlobalSource};
+pub use crate::global::{Global, GlobalEntropy, GlobalRngEntity};
+pub use crate::params::{RngEntity, RngEntityItem};
 pub use crate::plugin::EntropyPlugin;
 pub use crate::seed::RngSeed;
 pub use crate::traits::{

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,7 +3,7 @@ pub use crate::component::Entropy;
 pub use crate::global::{Global, GlobalEntropy, GlobalRngEntity};
 pub use crate::observers::{RngLinks, RngSource, SeedFromGlobal, SeedFromSource, SeedLinked};
 pub use crate::params::{RngEntity, RngEntityItem};
-pub use crate::plugin::{EntropyObserversPlugin, EntropyPlugin};
+pub use crate::plugin::{EntropyPlugin, EntropyRelationsPlugin};
 pub use crate::seed::RngSeed;
 pub use crate::traits::{
     ForkableAsRng, ForkableAsSeed, ForkableInnerRng, ForkableInnerSeed, ForkableRng, ForkableSeed,
@@ -15,7 +15,7 @@ pub use bevy_prng::WyRand;
 
 #[cfg(feature = "rand_chacha")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_chacha")))]
-pub use bevy_prng::{ChaCha12Rng, ChaCha20Rng, ChaCha8Rng};
+pub use bevy_prng::{ChaCha8Rng, ChaCha12Rng, ChaCha20Rng};
 
 #[cfg(feature = "rand_pcg")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_pcg")))]
@@ -24,7 +24,7 @@ pub use bevy_prng::{Pcg32, Pcg64, Pcg64Mcg};
 #[cfg(feature = "rand_xoshiro")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_xoshiro")))]
 pub use bevy_prng::{
-    Seed512, Xoroshiro128Plus, Xoroshiro128PlusPlus, Xoroshiro128StarStar, Xoroshiro64Star,
-    Xoroshiro64StarStar, Xoshiro128Plus, Xoshiro128PlusPlus, Xoshiro128StarStar, Xoshiro256Plus,
+    Seed512, Xoroshiro64Star, Xoroshiro64StarStar, Xoroshiro128Plus, Xoroshiro128PlusPlus,
+    Xoroshiro128StarStar, Xoshiro128Plus, Xoshiro128PlusPlus, Xoshiro128StarStar, Xoshiro256Plus,
     Xoshiro256PlusPlus, Xoshiro256StarStar, Xoshiro512Plus, Xoshiro512PlusPlus, Xoshiro512StarStar,
 };

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -75,18 +75,21 @@ where
 
     fn register_component_hooks(hooks: &mut bevy_ecs::component::ComponentHooks) {
         hooks
-            .on_insert(|mut world, entity, _| {
+            .on_insert(|mut world, context| {
                 let seed = world
-                    .get::<RngSeed<R>>(entity)
+                    .get::<RngSeed<R>>(context.entity)
                     .map(|seed| seed.clone_seed())
                     .unwrap();
                 world
                     .commands()
-                    .entity(entity)
+                    .entity(context.entity)
                     .insert(Entropy::<R>::from_seed(seed));
             })
-            .on_remove(|mut world, entity, _| {
-                world.commands().entity(entity).remove::<Entropy<R>>();
+            .on_remove(|mut world, context| {
+                world
+                    .commands()
+                    .entity(context.entity)
+                    .remove::<Entropy<R>>();
             });
     }
 }

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -124,8 +124,8 @@ mod tests {
 
         use bevy_prng::WyRand;
         use bevy_reflect::{
-            serde::{TypedReflectDeserializer, TypedReflectSerializer},
             FromReflect, GetTypeRegistration, TypeRegistry,
+            serde::{TypedReflectDeserializer, TypedReflectSerializer},
         };
         use ron::to_string;
         use serde::de::DeserializeSeed;

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -47,7 +47,6 @@ where
 {
     /// Create a new instance of [`RngSeed`] from a given `seed` value.
     #[inline]
-    #[must_use]
     fn from_seed(seed: R::Seed) -> Self {
         Self {
             seed,

--- a/tests/integration/determinism.rs
+++ b/tests/integration/determinism.rs
@@ -1,6 +1,6 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_prng::{ChaCha12Rng, ChaCha8Rng, WyRand};
+use bevy_prng::{ChaCha8Rng, ChaCha12Rng, WyRand};
 use bevy_rand::{
     global::GlobalRngEntity,
     prelude::{Entropy, EntropyPlugin, ForkableAsRng, ForkableRng, GlobalEntropy},
@@ -31,7 +31,7 @@ fn random_output_a(mut q_source: Query<&mut Entropy<ChaCha8Rng>, With<SourceA>>)
     let mut rng = q_source.single_mut();
 
     assert_eq!(
-        rng.gen::<u32>(),
+        rng.r#gen::<u32>(),
         3315785188,
         "SourceA does not match expected output"
     );
@@ -57,7 +57,7 @@ fn random_output_d(mut q_source: Query<&mut Entropy<ChaCha12Rng>, With<SourceD>>
     let mut rng = q_source.single_mut();
 
     assert_eq!(
-        rng.gen::<(u16, u16)>(),
+        rng.r#gen::<(u16, u16)>(),
         (41421, 7891),
         "SourceD does not match expected output"
     );

--- a/tests/integration/determinism.rs
+++ b/tests/integration/determinism.rs
@@ -2,9 +2,8 @@ use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_prng::{ChaCha12Rng, ChaCha8Rng, WyRand};
 use bevy_rand::{
-    global::GlobalSeed,
+    global::GlobalRngEntity,
     prelude::{Entropy, EntropyPlugin, ForkableAsRng, ForkableRng, GlobalEntropy},
-    traits::SeedSource,
 };
 use rand::prelude::Rng;
 
@@ -90,8 +89,8 @@ fn setup_sources(mut commands: Commands, mut rng: GlobalEntropy<ChaCha8Rng>) {
     commands.spawn((SourceE, rng.fork_as::<WyRand>()));
 }
 
-fn read_global_seed(rng: GlobalSeed<ChaCha8Rng>) {
-    assert_eq!(rng.get_seed(), &[2; 32]);
+fn read_global_seed(rng: GlobalRngEntity<ChaCha8Rng>) {
+    assert_eq!(rng.clone_seed(), [2; 32]);
 }
 
 /// Entities having their own sources side-steps issues with parallel execution and scheduling

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,2 +1,0 @@
-pub mod determinism;
-pub mod reseeding;

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -2,8 +2,8 @@ use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_prng::{ChaCha8Rng, WyRand};
 use bevy_rand::{
-    global::{Global, GlobalEntropy},
-    plugin::{EntropyPlugin, EntropyRelationPlugin},
+    global::{Global, GlobalEntropy, GlobalRng},
+    plugin::{EntropyObserversPlugin, EntropyPlugin},
     prelude::Entropy,
     seed::RngSeed,
     traits::{ForkableAsSeed, ForkableSeed, SeedSource},
@@ -163,7 +163,7 @@ fn observer_global_reseeding() {
 
     app.add_plugins((
         EntropyPlugin::<WyRand>::with_seed(seed),
-        EntropyRelationPlugin::<WyRand>::default(),
+        EntropyObserversPlugin::<WyRand, WyRand>::default(),
     ))
     .add_systems(
         Startup,
@@ -171,14 +171,11 @@ fn observer_global_reseeding() {
             |mut commands: Commands| {
                 commands.spawn_batch(vec![Target; 5]);
             },
-            |mut commands: Commands,
-             q_targets: Query<Entity, With<Target>>,
-             global: GlobalSource<WyRand>| {
-                let source = global.into_inner();
+            |q_targets: Query<Entity, With<Target>>, mut global: GlobalRng<WyRand>| {
                 let targets: Vec<_> = q_targets.iter().collect();
 
-                commands
-                    .rng::<WyRand>(source)
+                global
+                    .rng_commands()
                     .link_target_rngs(&targets)
                     .reseed_linked();
             },
@@ -253,7 +250,7 @@ fn generic_observer_reseeding_from_parent() {
 
     app.add_plugins((
         EntropyPlugin::<WyRand>::with_seed(seed),
-        EntropyRelationPlugin::<WyRand>::default(),
+        EntropyObserversPlugin::<WyRand, WyRand>::default(),
     ))
     .add_systems(
         Startup,
@@ -322,7 +319,7 @@ fn generic_observer_reseeding_children() {
 
     app.add_plugins((
         EntropyPlugin::<WyRand>::with_seed(seed),
-        EntropyRelationPlugin::<WyRand>::default(),
+        EntropyObserversPlugin::<WyRand, WyRand>::default(),
     ))
     .add_systems(
         Startup,

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -3,7 +3,7 @@ use bevy_ecs::prelude::*;
 use bevy_prng::{ChaCha8Rng, WyRand};
 use bevy_rand::{
     global::{Global, GlobalEntropy},
-    plugin::EntropyPlugin,
+    plugin::{EntropyPlugin, EntropyRelationPlugin},
     prelude::Entropy,
     seed::RngSeed,
     traits::{ForkableAsSeed, ForkableSeed, SeedSource},
@@ -151,7 +151,7 @@ fn component_fork_as_seed() {
 fn observer_global_reseeding() {
     use bevy_app::prelude::{PostUpdate, PreUpdate, Startup};
     use bevy_rand::{
-        global::GlobalSource, commands::RngCommandsExt, seed::RngSeed, traits::SeedSource,
+        commands::RngCommandsExt, global::GlobalSource, seed::RngSeed, traits::SeedSource,
     };
 
     #[derive(Component, Clone)]
@@ -161,71 +161,74 @@ fn observer_global_reseeding() {
 
     let mut app = App::new();
 
-    app.add_plugins((EntropyPlugin::<WyRand>::with_seed(seed),))
-        .add_systems(
-            Startup,
-            (
-                |mut commands: Commands| {
-                    commands.spawn_batch(vec![Target; 5]);
-                },
-                |mut commands: Commands,
-                 q_targets: Query<Entity, With<Target>>,
-                 global: GlobalSource<WyRand>| {
-                    let source = global.into_inner();
-                    let targets: Vec<_> = q_targets.iter().collect();
-
-                    commands
-                        .rng::<WyRand>(source)
-                        .link_target_rngs(&targets)
-                        .reseed_linked();
-                },
-            )
-                .chain(),
-        )
-        .add_systems(
-            PreUpdate,
-            |query: Query<&RngSeed<WyRand>, Without<Global>>| {
-                let expected = [
-                    2484862625678185386u64,
-                    10323237495534242118,
-                    14704548354072994214,
-                    14638519449267265798,
-                    11723565746675474547,
-                ];
-                let seeds = query.iter().map(RngSeed::<WyRand>::clone_seed);
-
-                expected
-                    .into_iter()
-                    .zip(seeds.map(u64::from_ne_bytes))
-                    .for_each(|(expected, actual)| assert_eq!(expected, actual));
+    app.add_plugins((
+        EntropyPlugin::<WyRand>::with_seed(seed),
+        EntropyRelationPlugin::<WyRand>::default(),
+    ))
+    .add_systems(
+        Startup,
+        (
+            |mut commands: Commands| {
+                commands.spawn_batch(vec![Target; 5]);
             },
-        )
-        .add_systems(
-            Update,
-            |mut commands: Commands, global: GlobalSource<WyRand>| {
+            |mut commands: Commands,
+             q_targets: Query<Entity, With<Target>>,
+             global: GlobalSource<WyRand>| {
+                let source = global.into_inner();
+                let targets: Vec<_> = q_targets.iter().collect();
+
                 commands
-                    .rng::<WyRand>(global.into_inner())
+                    .rng::<WyRand>(source)
+                    .link_target_rngs(&targets)
                     .reseed_linked();
             },
         )
-        .add_systems(
-            PostUpdate,
-            |query: Query<&RngSeed<WyRand>, Without<Global>>| {
-                let prev_expected = [
-                    2484862625678185386u64,
-                    10323237495534242118,
-                    14704548354072994214,
-                    14638519449267265798,
-                    11723565746675474547,
-                ];
-                let seeds = query.iter().map(RngSeed::<WyRand>::clone_seed);
+            .chain(),
+    )
+    .add_systems(
+        PreUpdate,
+        |query: Query<&RngSeed<WyRand>, Without<Global>>| {
+            let expected = [
+                2484862625678185386u64,
+                10323237495534242118,
+                14704548354072994214,
+                14638519449267265798,
+                11723565746675474547,
+            ];
+            let seeds = query.iter().map(RngSeed::<WyRand>::clone_seed);
 
-                prev_expected
-                    .into_iter()
-                    .zip(seeds.map(u64::from_ne_bytes))
-                    .for_each(|(expected, actual)| assert_ne!(expected, actual));
-            },
-        );
+            expected
+                .into_iter()
+                .zip(seeds.map(u64::from_ne_bytes))
+                .for_each(|(expected, actual)| assert_eq!(expected, actual));
+        },
+    )
+    .add_systems(
+        Update,
+        |mut commands: Commands, global: GlobalSource<WyRand>| {
+            commands.rng::<WyRand>(global.into_inner()).reseed_linked();
+        },
+    )
+    .add_systems(
+        PostUpdate,
+        |query: Query<&RngSeed<WyRand>, Without<Global>>| {
+            let prev_expected = [
+                2484862625678185386u64,
+                10323237495534242118,
+                14704548354072994214,
+                14638519449267265798,
+                11723565746675474547,
+            ];
+            let seeds = query.iter().map(RngSeed::<WyRand>::clone_seed);
+
+            assert_eq!(seeds.size_hint().0, 5);
+
+            prev_expected
+                .into_iter()
+                .zip(seeds.map(u64::from_ne_bytes))
+                .for_each(|(previous, actual)| assert_ne!(previous, actual));
+        },
+    );
 
     app.run();
 }
@@ -236,7 +239,7 @@ fn generic_observer_reseeding_from_parent() {
     use bevy_app::prelude::{PostUpdate, PreUpdate, Startup};
     use bevy_ecs::prelude::{Entity, With};
     use bevy_rand::{
-        global::GlobalSource, commands::RngCommandsExt, seed::RngSeed, traits::SeedSource,
+        commands::RngCommandsExt, global::GlobalSource, seed::RngSeed, traits::SeedSource,
     };
 
     let seed = [2u8; 8];
@@ -248,50 +251,53 @@ fn generic_observer_reseeding_from_parent() {
 
     let mut app = App::new();
 
-    app.add_plugins((EntropyPlugin::<WyRand>::with_seed(seed),))
-        .add_systems(
-            Startup,
-            |mut commands: Commands, global: GlobalSource<WyRand>| {
-                let global = global.into_inner();
-                let source = commands.spawn(Source).id();
-                let target = commands.spawn(Target).id();
+    app.add_plugins((
+        EntropyPlugin::<WyRand>::with_seed(seed),
+        EntropyRelationPlugin::<WyRand>::default(),
+    ))
+    .add_systems(
+        Startup,
+        |mut commands: Commands, global: GlobalSource<WyRand>| {
+            let global = global.into_inner();
+            let source = commands.spawn(Source).id();
+            let target = commands.spawn(Target).id();
 
-                commands.rng::<WyRand>(source).link_target_rngs(&[target]);
-                commands
-                    .rng::<WyRand>(global)
-                    .link_target_rngs(&[source])
-                    .reseed_linked();
-            },
-        )
-        .add_systems(PreUpdate, |query: Query<&RngSeed<WyRand>, With<Target>>| {
-            let expected = 6445550333322662121;
+            commands.rng::<WyRand>(source).link_target_rngs(&[target]);
+            commands
+                .rng::<WyRand>(global)
+                .link_target_rngs(&[source])
+                .reseed_linked();
+        },
+    )
+    .add_systems(PreUpdate, |query: Query<&RngSeed<WyRand>, With<Target>>| {
+        let expected = 6445550333322662121;
+        let seed = u64::from_ne_bytes(query.single().clone_seed());
+
+        assert_eq!(seed, expected);
+    })
+    .add_systems(PreUpdate, |query: Query<&RngSeed<WyRand>, With<Source>>| {
+        let expected = 2484862625678185386;
+        let seed = u64::from_ne_bytes(query.single().clone_seed());
+
+        assert_eq!(seed, expected);
+    })
+    .add_systems(
+        Update,
+        |mut commands: Commands, query: Query<Entity, With<Target>>| {
+            commands.rng::<WyRand>(query.single()).reseed_from_source();
+        },
+    )
+    .add_systems(
+        PostUpdate,
+        |query: Query<&RngSeed<WyRand>, With<Target>>| {
+            let prev_expected = 6445550333322662121;
+            let expected = 14968821102299026759;
             let seed = u64::from_ne_bytes(query.single().clone_seed());
 
+            assert_ne!(seed, prev_expected);
             assert_eq!(seed, expected);
-        })
-        .add_systems(PreUpdate, |query: Query<&RngSeed<WyRand>, With<Source>>| {
-            let expected = 2484862625678185386;
-            let seed = u64::from_ne_bytes(query.single().clone_seed());
-
-            assert_eq!(seed, expected);
-        })
-        .add_systems(
-            Update,
-            |mut commands: Commands, query: Query<Entity, With<Target>>| {
-                commands.rng::<WyRand>(query.single()).reseed_from_source();
-            },
-        )
-        .add_systems(
-            PostUpdate,
-            |query: Query<&RngSeed<WyRand>, With<Target>>| {
-                let prev_expected = 6445550333322662121;
-                let expected = 14968821102299026759;
-                let seed = u64::from_ne_bytes(query.single().clone_seed());
-
-                assert_ne!(seed, prev_expected);
-                assert_eq!(seed, expected);
-            },
-        );
+        },
+    );
 
     app.run();
 }
@@ -302,7 +308,7 @@ fn generic_observer_reseeding_children() {
     use bevy_app::prelude::{Last, PostUpdate, PreUpdate, Startup};
     use bevy_ecs::prelude::{Component, Entity, With, Without};
     use bevy_rand::{
-        global::GlobalSource, commands::RngCommandsExt, seed::RngSeed, traits::SeedSource,
+        commands::RngCommandsExt, global::GlobalSource, seed::RngSeed, traits::SeedSource,
     };
 
     let seed = [2u8; 8];
@@ -314,124 +320,127 @@ fn generic_observer_reseeding_children() {
 
     let mut app = App::new();
 
-    app.add_plugins((EntropyPlugin::<WyRand>::with_seed(seed),))
-        .add_systems(
-            Startup,
-            (
-                |mut commands: Commands| {
-                    commands.spawn_batch(vec![Target; 5]);
-                    commands.spawn(Source);
-                },
-                |mut commands: Commands,
-                 q_source: Single<Entity, With<Source>>,
-                 q_target: Query<Entity, With<Target>>,
-                 global: GlobalSource<WyRand>| {
-                    let global = global.into_inner();
-                    let source = q_source.into_inner();
+    app.add_plugins((
+        EntropyPlugin::<WyRand>::with_seed(seed),
+        EntropyRelationPlugin::<WyRand>::default(),
+    ))
+    .add_systems(
+        Startup,
+        (
+            |mut commands: Commands| {
+                commands.spawn_batch(vec![Target; 5]);
+                commands.spawn(Source);
+            },
+            |mut commands: Commands,
+             q_source: Single<Entity, With<Source>>,
+             q_target: Query<Entity, With<Target>>,
+             global: GlobalSource<WyRand>| {
+                let global = global.into_inner();
+                let source = q_source.into_inner();
 
-                    commands
-                        .rng::<WyRand>(source)
-                        .link_target_rngs(&q_target.iter().collect::<Vec<_>>());
-                    commands
-                        .rng::<WyRand>(global)
-                        .link_target_rngs(&[source])
-                        .reseed_linked();
-                },
-            )
-                .chain(),
-        )
-        .add_systems(
-            PreUpdate,
-            |query: Query<&RngSeed<WyRand>, (With<Target>, Without<Global>)>| {
-                let expected = [
-                    6445550333322662121u64,
-                    14968821102299026759,
-                    12617564484450995185,
-                    908888629357954483,
-                    6128439264405451235,
-                ];
-                let seeds = query.iter().map(RngSeed::<WyRand>::clone_seed);
-
-                assert_eq!(seeds.size_hint().0, 5);
-
-                expected
-                    .into_iter()
-                    .zip(seeds.map(u64::from_ne_bytes))
-                    .for_each(|(expected, actual)| {
-                        assert_eq!(expected, actual, "Expected output to match")
-                    });
+                commands
+                    .rng::<WyRand>(source)
+                    .link_target_rngs(&q_target.iter().collect::<Vec<_>>());
+                commands
+                    .rng::<WyRand>(global)
+                    .link_target_rngs(&[source])
+                    .reseed_linked();
             },
         )
-        .add_systems(PreUpdate, |query: Query<&RngSeed<WyRand>, With<Source>>| {
-            let expected = 2484862625678185386u64;
-            let seeds = u64::from_ne_bytes(query.single().clone_seed());
+            .chain(),
+    )
+    .add_systems(
+        PreUpdate,
+        |query: Query<&RngSeed<WyRand>, (With<Target>, Without<Global>)>| {
+            let expected = [
+                6445550333322662121u64,
+                14968821102299026759,
+                12617564484450995185,
+                908888629357954483,
+                6128439264405451235,
+            ];
+            let seeds = query.iter().map(RngSeed::<WyRand>::clone_seed);
 
-            assert_eq!(expected, seeds, "Expected seeds to match");
-        })
-        .add_systems(
-            Update,
-            |mut commands: Commands, query: Query<Entity, With<Source>>| {
-                for entity in &query {
-                    commands.rng::<WyRand>(entity).reseed_linked();
-                }
-            },
-        )
-        .add_systems(
-            PostUpdate,
-            |query: Query<&RngSeed<WyRand>, (With<Target>, Without<Global>)>| {
-                let prev_expected = [
-                    6445550333322662121u64,
-                    14968821102299026759,
-                    12617564484450995185,
-                    908888629357954483,
-                    6128439264405451235,
-                ];
+            assert_eq!(seeds.size_hint().0, 5);
 
-                let expected = [
-                    13007546668837876556u64,
-                    11167966742313596632,
-                    6059854582339877554,
-                    16378674538987011914,
-                    14627163487140195445,
-                ];
+            expected
+                .into_iter()
+                .zip(seeds.map(u64::from_ne_bytes))
+                .for_each(|(expected, actual)| {
+                    assert_eq!(expected, actual, "Expected output to match")
+                });
+        },
+    )
+    .add_systems(PreUpdate, |query: Query<&RngSeed<WyRand>, With<Source>>| {
+        let expected = 2484862625678185386u64;
+        let seeds = u64::from_ne_bytes(query.single().clone_seed());
 
-                prev_expected
-                    .into_iter()
-                    .zip(expected)
-                    .zip(
-                        query
-                            .iter()
-                            .map(RngSeed::<WyRand>::clone_seed)
-                            .map(u64::from_ne_bytes),
-                    )
-                    .for_each(|((previous, expected), actual)| {
-                        // Must not equal the previous seeds.
-                        assert_ne!(
-                            previous, actual,
-                            "Expected output not to match previous output"
-                        );
-                        // Should equal the expected updated seeds.
-                        assert_eq!(expected, actual, "Expected output to be updated")
-                    });
-            },
-        )
-        .add_systems(
-            Last,
-            |source: Query<&RngSeed<WyRand>, With<Source>>,
-             children: Query<&RngSeed<WyRand>, (Without<Source>, Without<Global>)>| {
-                // Check we have the correct amount of allocated RNG entities
-                assert_eq!(
-                    source.iter().size_hint().0,
-                    1,
-                    "Only one SOURCE should exist"
-                );
-                assert_eq!(
-                    children.iter().size_hint().0,
-                    5,
-                    "Only 5 TARGET should exist"
-                );
-            },
-        );
+        assert_eq!(expected, seeds, "Expected seeds to match");
+    })
+    .add_systems(
+        Update,
+        |mut commands: Commands, query: Query<Entity, With<Source>>| {
+            for entity in &query {
+                commands.rng::<WyRand>(entity).reseed_linked();
+            }
+        },
+    )
+    .add_systems(
+        PostUpdate,
+        |query: Query<&RngSeed<WyRand>, (With<Target>, Without<Global>)>| {
+            let prev_expected = [
+                6445550333322662121u64,
+                14968821102299026759,
+                12617564484450995185,
+                908888629357954483,
+                6128439264405451235,
+            ];
+
+            let expected = [
+                13007546668837876556u64,
+                11167966742313596632,
+                6059854582339877554,
+                16378674538987011914,
+                14627163487140195445,
+            ];
+
+            prev_expected
+                .into_iter()
+                .zip(expected)
+                .zip(
+                    query
+                        .iter()
+                        .map(RngSeed::<WyRand>::clone_seed)
+                        .map(u64::from_ne_bytes),
+                )
+                .for_each(|((previous, expected), actual)| {
+                    // Must not equal the previous seeds.
+                    assert_ne!(
+                        previous, actual,
+                        "Expected output not to match previous output"
+                    );
+                    // Should equal the expected updated seeds.
+                    assert_eq!(expected, actual, "Expected output to be updated")
+                });
+        },
+    )
+    .add_systems(
+        Last,
+        |source: Query<&RngSeed<WyRand>, With<Source>>,
+         children: Query<&RngSeed<WyRand>, (Without<Source>, Without<Global>)>| {
+            // Check we have the correct amount of allocated RNG entities
+            assert_eq!(
+                source.iter().size_hint().0,
+                1,
+                "Only one SOURCE should exist"
+            );
+            assert_eq!(
+                children.iter().size_hint().0,
+                5,
+                "Only 5 TARGET should exist"
+            );
+        },
+    );
 
     app.run();
 }

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -353,21 +353,22 @@ fn generic_observer_reseeding_children() {
             expected
                 .into_iter()
                 .zip(seeds.map(u64::from_ne_bytes))
-                .for_each(|(expected, actual)| assert_eq!(expected, actual));
+                .for_each(|(expected, actual)| {
+                    assert_eq!(expected, actual, "Expected output to match")
+                });
         },
     )
     .add_systems(PreUpdate, |query: Query<&RngSeed<WyRand>, With<Source>>| {
         let expected = 2484862625678185386u64;
         let seeds = u64::from_ne_bytes(query.single().clone_seed());
 
-        assert_eq!(expected, seeds);
+        assert_eq!(expected, seeds, "Expected seeds to match");
     })
     .add_systems(
         Update,
         |mut commands: Commands, query: Query<Entity, With<Source>>| {
             for entity in &query {
                 commands.trigger_targets(SeedChildren::<WyRand>::default(), entity);
-                println!("WIN");
             }
         },
     )
@@ -381,12 +382,13 @@ fn generic_observer_reseeding_children() {
                 908888629357954483,
                 6128439264405451235,
             ];
+
             let expected = [
-                2656876351602726802u64,
-                4226413670151402273,
-                2344778986622729714,
-                9109365740673988404,
-                6101264679293753504,
+                13007546668837876556u64,
+                11167966742313596632,
+                6059854582339877554,
+                16378674538987011914,
+                14627163487140195445,
             ];
 
             prev_expected
@@ -400,9 +402,12 @@ fn generic_observer_reseeding_children() {
                 )
                 .for_each(|((previous, expected), actual)| {
                     // Must not equal the previous seeds.
-                    assert_ne!(previous, actual);
+                    assert_ne!(
+                        previous, actual,
+                        "Expected output not to match previous output"
+                    );
                     // Should equal the expected updated seeds.
-                    assert_eq!(expected, actual)
+                    assert_eq!(expected, actual, "Expected output to be updated")
                 });
         },
     )
@@ -411,8 +416,16 @@ fn generic_observer_reseeding_children() {
         |source: Query<&RngSeed<WyRand>, With<Source>>,
          children: Query<&RngSeed<WyRand>, (Without<Source>, Without<Global>)>| {
             // Check we have the correct amount of allocated RNG entities
-            assert_eq!(source.iter().size_hint().0, 1);
-            assert_eq!(children.iter().size_hint().0, 5);
+            assert_eq!(
+                source.iter().size_hint().0,
+                1,
+                "Only one SOURCE should exist"
+            );
+            assert_eq!(
+                children.iter().size_hint().0,
+                5,
+                "Only 5 TARGET should exist"
+            );
         },
     );
 

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -260,7 +260,7 @@ pub fn generic_observer_reseeding_from_parent() {
     .add_systems(
         Update,
         |mut commands: Commands, query: Query<RngEntity<WyRand>, With<Target>>| {
-            commands.rng(&query.single()).reseed_from_source();
+            commands.rng_entity(&query.single()).reseed_from_source();
         },
     )
     .add_systems(
@@ -342,7 +342,7 @@ pub fn generic_observer_reseeding_children() {
         Update,
         |mut commands: Commands, query: Query<RngEntity<WyRand>, With<Source>>| {
             for entity in &query {
-                commands.rng(&entity).reseed_linked();
+                commands.rng_entity(&entity).reseed_linked();
             }
         },
     )

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -367,6 +367,7 @@ fn generic_observer_reseeding_children() {
         |mut commands: Commands, query: Query<Entity, With<Source>>| {
             for entity in &query {
                 commands.trigger_targets(SeedChildren::<WyRand>::default(), entity);
+                println!("WIN");
             }
         },
     )

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::type_complexity)]
-pub mod integration;
+#[path = "integration/determinism.rs"]
+pub mod determinism;
+#[path = "integration/reseeding.rs"]
+pub mod reseeding;
 
 #[cfg(target_arch = "wasm32")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);

--- a/tutorial/02-basic-usage.md
+++ b/tutorial/02-basic-usage.md
@@ -20,7 +20,7 @@ When using `GlobalEntropy`, the way to ensure deterministic output/usage with th
 
 - One time or non-looping accesses when generating random numbers.
 - Iterating over set loops/ranges.
-- Systems constrained with clear priorities so there are no ambiguities.
+- Systems constrained with clear priorities and ordering so there are no ambiguities.
 
 An example of a guaranteed deterministic system is perhaps spawning new entities with a randomised component value:
 

--- a/tutorial/04-seeding.md
+++ b/tutorial/04-seeding.md
@@ -35,7 +35,7 @@ But for most purposes, you don't actually *need* to know its exact internal stat
 ```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::prelude::Entropy;
+use bevy_rand::prelude::RngSeed;
 
 #[derive(Component)]
 struct Source;
@@ -46,7 +46,7 @@ fn setup_source(mut commands: Commands) {
             Source,
             // This will yield a random `RngSeed<WyRand>` and then an `Entropy<WyRand>`
             // with the same random seed
-            Entropy::<WyRand>::default(),
+            RngSeed::<WyRand>::default(),
         ));
 }
 ```

--- a/tutorial/04-seeding.md
+++ b/tutorial/04-seeding.md
@@ -80,15 +80,15 @@ In order to ensure that new seeds always proliferate into updating `Entropy` com
 ```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::prelude::{RngSeed, SeedSource, GlobalSource};
+use bevy_rand::prelude::{RngSeed, SeedSource, GlobalRngEntity};
 
 #[derive(Component)]
 struct Source;
 
-fn setup_source(mut commands: Commands, global: GlobalSource<WyRand>) {
+fn setup_source(mut global: GlobalRngEntity<WyRand>) {
     let new_seed = [42; 8]; // This seed has been chosen as random
 
-    commands.entity(*global).insert(RngSeed::<WyRand>::from_seed(new_seed));
+    global.rng_commands().reseed(new_seed);
 }
 ```
 

--- a/tutorial/05-observer-driven-reseeding.md
+++ b/tutorial/05-observer-driven-reseeding.md
@@ -41,7 +41,7 @@ fn link_and_seed_target_rngs_with_global(q_targets: Query<Entity, With<Target>>,
 }
 ```
 
-In the above example, we have created a relationship between the `Global` `WyRand` source and all `Target` entities. The above system creates the relations and then emits a reseeding event, causing all `Target` entities to receive a new `RngSeed` component from the `Global` source. This in turn initialises an `Entropy` component on each `Target` entity with the received seed.
+In the above example, we have created a relationship between the `GlobalRngEntity<WyRand>` source and all `Target` entities. The above system creates the relations and then emits a reseeding event, causing all `Target` entities to receive a new `RngSeed` component from the `Global` source. This in turn initialises an `Entropy` component on each `Target` entity with the received seed.
 
 If you want to spawn related entities directly, then you can! The example below will create three `Target` entities that are related to the `Global` source, and will be seeded automatically once spawned.
 
@@ -100,7 +100,7 @@ struct Target;
 
 fn pull_seeds_from_source(mut commands: Commands, q_targets: Query<RngEntity<WyRand>, With<Target>>) {
     for entity in q_targets {
-        commands.rng(&entity).reseed_from_source();
+        commands.rng_entity(&entity).reseed_from_source();
     }
 }
 ```

--- a/tutorial/05-observer-driven-reseeding.md
+++ b/tutorial/05-observer-driven-reseeding.md
@@ -1,9 +1,9 @@
-# EXPERIMENTAL - Observer-driven Reseeding
+# Observer-driven and Command-based Reseeding
 
 The following feature is _experimental_ so to enable it, you'll need to edit your Cargo.toml file and change the dependency declaration for `bevy_rand` to have `features=["experimental"]` applied. Once done, you'll get access to some utils that will enable easy setup of observer driven reseeding utilities for managing when entities with `Entropy`s obtain new seeds from which sources. Keep in mind, this feature is not *stable* and will be subject to further work and iteration, so if problems and issues are encountered, please do create issues outlining the use-cases and difficulties.
 
 ```toml
-bevy_rand = { version = "0.10", features = ["rand_chacha", "wyrand", "experimental"] }
+bevy_rand = { version = "0.10", features = ["rand_chacha", "wyrand"] }
 ```
 
 By default, when the `experimental` feature is enabled, you'll be able to trigger a reseeding for a given entity either by pulling from a global source, or by providing a set seed value. This does not require any specific setup, and can simply be triggered by emitting the event on the entity needing to be reseeded. ALl observer events require providing a generic for the RNG algorithm to be targetted, as an entity could have multiple RNG sources attached to it.

--- a/tutorial/05-observer-driven-reseeding.md
+++ b/tutorial/05-observer-driven-reseeding.md
@@ -1,55 +1,101 @@
 # Observer-driven and Command-based Reseeding
 
-The following feature is _experimental_ so to enable it, you'll need to edit your Cargo.toml file and change the dependency declaration for `bevy_rand` to have `features=["experimental"]` applied. Once done, you'll get access to some utils that will enable easy setup of observer driven reseeding utilities for managing when entities with `Entropy`s obtain new seeds from which sources. Keep in mind, this feature is not *stable* and will be subject to further work and iteration, so if problems and issues are encountered, please do create issues outlining the use-cases and difficulties.
+Managing the seeding of related RNGs manually can be complex and also boilerplate-y, so `bevy_rand` provides a commands API powered by observers and bevy relations to make it much more easy to setup and maintain. This way, pushing a new seed to a single "source" RNG will then automatically push out new seeds to all linked "target" RNGs. It can also be set up for seeding between different kinds of PRNG, but it does require the addition of an extra plugin in order to facilitate this particular case.
 
-```toml
-bevy_rand = { version = "0.10", features = ["rand_chacha", "wyrand"] }
+The nature of the relations are strictly either One to One or One to Many. Many to Many relations are **not** supported, as it does not make sense for PRNG to have multiple source PRNGs.
+
+```rust
+use bevy_app::prelude::*;
+use bevy_prng::{ChaCha8Rng, WyRand};
+use bevy_rand::prelude::{EntropyPlugin, EntropyObserversPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins((
+            // First initialise the RNGs
+            EntropyPlugin::<ChaCha8Rng>::default(),
+            EntropyPlugin::<WyRand>::default(),
+            // This initialises observers for WyRand -> WyRand seeding relations
+            EntropyObserversPlugin::<WyRand, WyRand>::default(),
+            // This initialises observers for ChaCha8Rng -> WyRand seeding relations
+            EntropyObserversPlugin::<ChaCha8Rng, WyRand>::default(),
+        ))
+        .run();
+}
 ```
 
-By default, when the `experimental` feature is enabled, you'll be able to trigger a reseeding for a given entity either by pulling from a global source, or by providing a set seed value. This does not require any specific setup, and can simply be triggered by emitting the event on the entity needing to be reseeded. ALl observer events require providing a generic for the RNG algorithm to be targetted, as an entity could have multiple RNG sources attached to it.
+Once the plugins are initialised, various observer systems are ready to begin listening to various linking and reseeding events. Relations can exist between a global source and "local" sources, or between other entity local sources. So for example, a single `Global` source can seed many `Player` entities with their own RNGs, and to reseed all `Player` entities, you just need to push a new seed to the global source, or tell the global source to reseed all its linked RNGs.
 
-```rust ignore
+```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::observers::SeedFromGlobal;
+use bevy_rand::prelude::{RngEntity, GlobalRngEntity};
 
 #[derive(Component)]
 struct Target;
 
-fn reseed_target_entities_from_global(mut commands: Commands, mut q_targets: Query<Entity, With<Target>>) {
-    for target in &q_targets {
-        commands.trigger_targets(SeedFromGlobal::<WyRand>::default(), target);
-    }
+fn link_and_seed_target_rngs_with_global(q_targets: Query<Entity, With<Target>>, mut global: GlobalRngEntity<WyRand>) {
+    let targets = q_targets.iter().collect::<Vec<_>>();
+
+    global.rng_commands().link_target_rngs(&targets).reseed_linked();
 }
 ```
+
+In the above example, we have created a relationship between the `Global` `WyRand` source and all `Target` entities. The above system creates the relations and then emits a reseeding event, causing all `Target` entities to receive a new `RngSeed` component from the `Global` source. This in turn initialises an `Entropy` component on each `Target` entity with the received seed.
+
+The `GlobalRngEntity` is a special `SystemParam` that access the `Global` source `Entity` for a particular PRNG type. This then allows you to directly ask for an `RngEntityCommands` via the `rng_commands()` method. With this, you can link and seed your Source or Targets.
 
 Alternatively, one can provide a set seed to reseed all target entities with:
 
-```rust ignore
+```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::observers::ReseedRng;
+use bevy_rand::prelude::*;
 
 #[derive(Component)]
 struct Target;
 
-fn reseed_target_entities_from_set_seed(mut commands: Commands, mut q_targets: Query<Entity, With<Target>>) {
+fn intialise_rng_entities_with_set_seed(mut commands: Commands, mut q_targets: Query<Entity, With<Target>>) {
     let seed = u64::to_ne_bytes(42); 
 
     for target in &q_targets {
-        commands.trigger_targets(ReseedRng::<WyRand>::new(seed), target);
+        commands.entity(target).rng::<WyRand>().reseed(seed);
     }
 }
 ```
 
-With these observers, you can initialise entropy components on all targetted entities simply by triggering a reseed event on them. As long as your entities have been spawned with a component you can target them with, they will automatically be given an `RngSeed` component (which stores the initial seed value) and an `Entropy`.
+The commands API takes an `EntityCommands` and extends it to provide an `rng()` method that takes a generic parameter to define which PRNG you want to initialise/use, and then provides methods to trigger events for seeding either the entity itself, or creating relations between other entities for seeding.
 
-Additionally, you can link entities to draw their seeds from other source entities instead of the global resources. So one `Source` entity can then seed many `Target` entities, and whenever the `Source` entity is updated with a new seed value, it then automatically pushes new seeds to its linked targets. Note: this is NOT a `bevy_hierarchy` relationship, and while the `Source` will have "child" entities, removing/despawning the source entity will *not* despawn the children entities. They will simply no longer have a valid "link". A new link can be established by triggering another "link" event.
+For entities that already have `RngSeed` attached to them, you can make use of `RngEntity` to query them. `Commands` also has a `rng()` method provided that takes a `&RngEntity` to give a `RngEntityCommands` without needing to explicitly provide the generics parameter to yield the correct PRNG target.
 
-```rust ignore
+These command APIs are designed to alleviate or reduce some of the generic typing around the Rng components, so to make it less error prone and more robust that you are targetting the correct PRNG type, and also to make it easier on querying and managing more complex relations of dependencies between RNGs for seeding.
+
+Once the relations are created, it becomes easy to pull new seeds from sources/global using the commands API:
+
+```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::observers::{LinkRngSourceToTarget, SeedFromGlobal};
+use bevy_rand::prelude::{RngEntity, RngCommandsExt};
+
+#[derive(Component)]
+struct Source;
+
+#[derive(Component)]
+struct Target;
+
+fn pull_seeds_from_source(mut commands: Commands, q_targets: Query<RngEntity<WyRand>, With<Target>>) {
+    for entity in q_targets {
+        commands.rng(&entity).reseed_from_source();
+    }
+}
+```
+
+Of course, one _can_ also make use of the observer events directly, though it does require more typing to be involved. An example below:
+
+```rust
+use bevy_ecs::{prelude::*, relationship::RelatedSpawnerCommands};
+use bevy_prng::WyRand;
+use bevy_rand::prelude::{SeedFromGlobal, RngSource};
 
 #[derive(Component)]
 struct Source;
@@ -58,27 +104,28 @@ struct Source;
 struct Target;
 
 fn initial_setup(mut commands: Commands) {
-    // Create the source entity and get the Entity id.
-    let source = commands.spawn(Source).id();
-
-    // Spawn many target entities
-    commands.spawn_batch(vec![Target; 5]);
-
-    // Link the target entities to the Source entity
-    commands.trigger(LinkRngSourceToTarget::<Source, Target, WyRand>::default());
+    // Create the source entity with its related target entities and get the Entity id.
+    let source = commands
+        .spawn(Source)
+        .with_related(|s: &mut RelatedSpawnerCommands<'_, RngSource<WyRand, WyRand>>| {
+            vec![Target; 5].into_iter().for_each(|bundle| {
+                s.spawn(bundle);
+            });
+        })
+        .id();
 
     // Initialise the Source entity to be an RNG source and then seed all its
     // linked entities.
-    commands.trigger_targets(SeedFromGlobal::<WyRand>::default(), source);
+    commands.trigger_targets(SeedFromGlobal::<WyRand, WyRand>::default(), source);
 }
 ```
 
-Once the link has been created, child entities can also pull a new seed from its parent source. So if you want to reseed *one* entity from its parent source, but not all of the entities that have the same source, you can use the `SeedFromParent` observer event to achieve this.
+Once the link has been created, child entities can also pull a new seed from its parent source. So if you want to reseed *one* entity from its parent source, but not all of the entities that have the same source, you can use the `SeedFromSource` observer event to achieve this.
 
-```rust ignore
+```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::observers::SeedFromParent;
+use bevy_rand::observers::SeedFromSource;
 
 #[derive(Component)]
 struct Source;
@@ -88,7 +135,22 @@ struct Target;
 
 fn pull_seed_from_parent(mut commands: Commands, mut q_targets: Query<Entity, With<Target>>) {
     for target in &q_targets {
-        commands.trigger_targets(SeedFromParent::<WyRand>::default(), target);
+        commands.trigger_targets(SeedFromSource::<WyRand, WyRand>::default(), target);
     }
 }
 ```
+
+## Note about relations between PRNG types
+
+As covered in Chapter One: "Selecting and using PRNG Algorithms", when creating relationship between different PRNG types, do not seed a stronger PRNG from a weaker one. CSPRNGs like `ChaCha8` should be seeded by either other `ChaCha8` sources or "stronger" sources like `ChaCha12` or `ChaCha20`, never from ones like `WyRand` or `Xoshiro256StarStar`. Always go from stronger to weaker, or same to same, never from weaker to stronger. Doing so makes it easier to predict the seeded PRNG, and reduces the advantage of using a CSPRNG in the first place.
+
+So in summary:
+
+| Source     | Target     |         |
+| ---------- | ---------- | ------- |
+| `ChaCha8`  | `Wyrand`   | ✅ Good |
+| `ChaCha8`  | `WyRand`   | ✅ Good |
+| `ChaCha12` | `ChaCha8`  | ✅ Good |
+| `WyRand`   | `WyRand`   | ✅ Good |
+| `Wyrand`   | `ChaCha8`  | ❌ Bad  |
+| `ChaCha8`  | `ChaCha12` | ❌ Bad  |


### PR DESCRIPTION
This PR will represent a major refactor of aspects of `bevy_rand` with the observers feature, making use of relations to simplify some of the internal code and also redoing the API for interacting with the observers to make use of a more streamlined commands API.

The work here will be destined for the next version of Bevy, due to being dependent on a number of features currently only present on the `main` branch.

Goals of this PR:
- [x] - Rework observer systems to make use of relations
- [x] - Initial commands API for handling linking/seeding related RNGs
- [x] - Split plugin for more granular configuration to support Rng1 -> Rng2 forking via observers
- [x] - Update documentation to reflect new APIs/approaches.
- [x] - Update Migration guide for new API changes
- [x] - Documentation pass before merging
