### PR TITLE
feat: Optional bevy_reflect for better `no_std` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - v0.15
+      - v0.16
 
 env:
   RUSTFLAGS: -D warnings
@@ -32,9 +32,6 @@ jobs:
       - name: Install Clippy
         run: rustup component add clippy
         if: startsWith(matrix.rust, 'nightly')
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-        if: startsWith(matrix.os, 'ubuntu')
       - name: Install wasm-pack
         uses: taiki-e/install-action@wasm-pack
         if: startsWith(matrix.os, 'ubuntu')
@@ -45,6 +42,8 @@ jobs:
         run: cargo check --locked --no-default-features --features rand_xoshiro,rand_pcg --workspace
       - name: Test with all features enabled
         run: cargo test --locked --all-features
+      - name: Test Docs
+        run: cargo doc --locked
       - name: Test wasm
         env:
           RUSTFLAGS: --cfg getrandom_backend="wasm_js"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo clippy --locked --workspace --all-features --all-targets -- -Dwarnings
         if: startsWith(matrix.rust, 'nightly')
       - name: No Default Feature checks
-        run: cargo check --locked --no-default-features --workspace
+        run: cargo check --locked --no-default-features --features rand_xoshiro,rand_pcg --workspace
       - name: Test with all features enabled
         run: cargo test --locked --all-features
       - name: Test wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_prng"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bevy_reflect",
  "rand_chacha 0.9.0",
@@ -190,7 +190,7 @@ checksum = "86f1275dfb4cfef4ffc90c3fa75408964864facf833acc932413d52aa5364ba4"
 
 [[package]]
 name = "bevy_rand"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -290,9 +290,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "equivalent",
  "serde",
@@ -1184,9 +1184,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,12 @@ authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 edition = "2024"
 repository = "https://github.com/Bluefinger/bevy_rand"
 license = "MIT OR Apache-2.0"
-version = "0.10.0"
+version = "0.11.0"
 rust-version = "1.85.0"
 
 [workspace.dependencies]
-bevy_app = { version = "0.16.0", default-features = false, features = [
-    "bevy_reflect",
-] }
-bevy_ecs = { version = "0.16.0", default-features = false, features = [
-    "bevy_reflect",
-] }
+bevy_app = { version = "0.16.0", default-features = false }
+bevy_ecs = { version = "0.16.0", default-features = false }
 bevy_reflect = { version = "0.16.0", default-features = false }
 serde = { version = "1.0.218", default-features = false, features = ["derive"] }
 rand_core = { version = "0.9.3", features = ["os_rng"] }
@@ -40,7 +36,13 @@ exclude = ["/.*", "Cargo.lock"]
 rust-version = { workspace = true }
 
 [features]
-default = ["serialize", "thread_local_entropy", "std", "compat"]
+default = ["serialize", "thread_local_entropy", "std", "compat", "bevy_reflect"]
+bevy_reflect = [
+    "dep:bevy_reflect",
+    "bevy_app/bevy_reflect",
+    "bevy_ecs/bevy_reflect",
+    "bevy_prng/bevy_reflect",
+]
 compat = ["bevy_prng/compat", "dep:rand_core_06"]
 std = ["bevy_prng/std", "getrandom/std"]
 experimental = []
@@ -55,8 +57,8 @@ wasm_js = ["getrandom/wasm_js"]
 [dependencies]
 bevy_app.workspace = true
 bevy_ecs.workspace = true
-bevy_reflect.workspace = true
-bevy_prng = { path = "bevy_prng", version = "0.10" }
+bevy_reflect = { workspace = true, optional = true }
+bevy_prng = { path = "bevy_prng", version = "0.11" }
 
 # others
 getrandom = "0.3.1"
@@ -70,7 +72,7 @@ serde = { workspace = true, optional = true }
 # cannot be out of step with bevy_rand due to dependencies on traits
 # and implementations between the two crates.
 [target.'cfg(any())'.dependencies]
-bevy_prng = { path = "bevy_prng", version = "=0.10" }
+bevy_prng = { path = "bevy_prng", version = "=0.11" }
 
 [dev-dependencies]
 bevy_app = { version = "0.16.0", default-features = false, features = [
@@ -80,7 +82,7 @@ bevy_ecs = { version = "0.16.0", default-features = false, features = [
     "bevy_reflect",
 ] }
 bevy_math = { version = "0.16.0", package = "bevy_math" }
-bevy_prng = { path = "bevy_prng", version = "0.10", features = [
+bevy_prng = { path = "bevy_prng", version = "0.11", default-features = false, features = [
     "rand_chacha",
     "wyrand",
 ] }

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -75,3 +75,13 @@ bevy_rand = { version = "0.10", features = ["wyrand", "compat"] }
 Various observer events have been removed and replaced with Bevy's relations APIs. `LinkRngSourceToTarget`, `ReseedRng`, `RngChildren` and `RngParent` no longer exist. Instead, for queries, `RngLinks` and `RngSource` are the relations components, and `SeedFromGlobal`, `SeedFromSource`, and `SeedLinked` are the new observer events. For the most part, it is recommended to use the new Commands APIs provided by `RngCommandsExt` & `RngEntityCommandsExt`.
 
 To enable the full relations API and features, make sure to add the `EntropyRelationsPlugin` to your bevy app.
+
+## Migrating from v0.10 to v0.11
+
+The breaking change here is that when `bevy_rand` has `default-features` set to `false`, it won't bring in `bevy_reflect` support any more. This is so that for more resource constrained `no_std` platforms, reflection support can be opted out in order to conserve memory usage. Reflection support can then be added back in by explicitly specifying `bevy_reflect` as a feature:
+
+```toml
+bevy_rand = { version = "0.11", default-features = false, features = ["bevy_reflect", "wyrand"] }
+```
+
+This change does not affect default/`std` usage of `bevy_rand`, which includes `bevy_reflect` support out of the box.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Notes on migrating between versions can be found [here](MIGRATIONS.md).
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ All supported PRNGs and compatible structs are provided by the `bevy_prng` crate
 #### `bevy_rand` feature activation
 ```toml
 rand_core = "0.9"
-bevy_rand = { version = "0.10", features = ["rand_chacha", "wyrand"] }
+bevy_rand = { version = "0.11", features = ["rand_chacha", "wyrand"] }
 ```
 
 #### `bevy_prng` feature activation
 ```toml
 rand_core = "0.9"
-bevy_rand = "0.10"
-bevy_prng = { version = "0.10", features = ["rand_chacha", "wyrand"] }
+bevy_rand = "0.11"
+bevy_prng = { version = "0.11", features = ["rand_chacha", "wyrand"] }
 ```
 
 The summary of what RNG algorithm to choose is: pick `wyrand` for almost all cases as it is faster and more portable than other algorithms. For cases where you need the extra assurance of entropy quality (as in, better and much less predictable 'randomness', etc), then use `rand_chacha`. For more information, [go here](https://docs.rs/bevy_rand/latest/bevy_rand/tutorial/ch01_choosing_prng/index.html).
@@ -39,18 +39,18 @@ DO **NOT** use `bevy_rand` for actual security purposes, as this requires much m
 `bevy_rand` is `no_std` compatible, but it requires disabling default features. It also assumes that `alloc` is available, just the same as `bevy`. Certain features like `thread_local_entropy` are not available for `no_std` due to requiring `std` specific functionalities like thread locals.
 
 ```toml
-bevy_rand = { version = "0.10", default-features = false, features = ["rand_chacha", "wyrand"] }
+bevy_rand = { version = "0.11", default-features = false, features = ["rand_chacha", "wyrand"] }
 ```
 
 All PRNG backends should support `no_std` environments. Furthermore, `getrandom` needs to be configured to support the platform, so in the case of a `no_std` environment such as an embedded board or console, you'll need to implement the [custom backend for `getrandom` to compile](https://docs.rs/getrandom/latest/getrandom/#custom-backend).
 
 #### Usage within Web WASM environments
 
-From `v0.9` onwards, `bevy_rand` no longer assumes that `bevy` will be run in a web environment when compiled for WASM. To enable that in `v0.10`, just paste the following into your `Cargo.toml` for your binary crate:
+From `v0.9` onwards, `bevy_rand` no longer assumes that `bevy` will be run in a web environment when compiled for WASM. To enable that in `v0.11`, just paste the following into your `Cargo.toml` for your binary crate:
 
 ```toml
 [target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
-bevy_rand = { version = "0.10", features = ["wasm_js"] }
+bevy_rand = { version = "0.11", features = ["wasm_js"] }
 ```
 
 This enables the `wasm_js` backend to be made available for `getrandom`, but it doesn't actually build. The next step is to either edit your `.cargo/config.toml` with the below configuration:
@@ -145,6 +145,7 @@ fn setup_npc_from_source(
 
 ## Features
 
+- **`bevy_reflect`** - Enables reflection support for all `bevy_rand` types. Enabled by default.
 - **`std`** - Enables support for `std` environment, allows enabling `std` specific optimisations for `rand_chacha` and more. Enabled by default.
 - **`thread_local_entropy`** - Enables `ThreadLocalEntropy`, overriding `SeedableRng::from_entropy` implementations to make use of thread local entropy sources for faster PRNG initialisation. Requires `std` environments so it enables the `std` feature. Enabled by default.
 - **`serialize`** - Enables `Serialize` and `Deserialize` derives. Enabled by default.
@@ -158,24 +159,24 @@ fn setup_npc_from_source(
 
 ## Supported Versions & MSRV
 
-`bevy_rand` uses the same MSRV as `bevy`.
+`bevy_rand` uses the same MSRV policy as `bevy`.
 
-| `bevy` | `bevy_rand`  |
-| ------ | ------------ |
-| v0.16  | v0.10        |
-| v0.15  | v0.8 - v0.9  |
-| v0.14  | v0.7         |
-| v0.13  | v0.5 - v0.6  |
-| v0.12  | v0.4         |
-| v0.11  | v0.2 - v0.3  |
-| v0.10  | v0.1         |
+| `bevy` | `bevy_rand`   |
+| ------ | ------------- |
+| v0.16  | v0.10 - v0.11 |
+| v0.15  | v0.8 - v0.9   |
+| v0.14  | v0.7          |
+| v0.13  | v0.5 - v0.6   |
+| v0.12  | v0.4          |
+| v0.11  | v0.2 - v0.3   |
+| v0.10  | v0.1          |
 
 The versions of `rand_core`/`rand` that `bevy_rand` is compatible with is as follows:
 
-| `bevy_rand`   | `rand_core` | `rand` | `getrandom` | `compat` feature               |
-| ------------- | ----------- | ------ | ----------- | ------------------------------ |
-| v0.10         | v0.9        | v0.9   | v0.3        | ✅ (supports `rand_core` v0.6) |
-| v0.1 -> v0.9  | v0.6        | v0.8   | v0.2        | ❌                             |
+| `bevy_rand`    | `rand_core` | `rand` | `getrandom` | `compat` feature               |
+| -------------- | ----------- | ------ | ----------- | ------------------------------ |
+| v0.10 -> v0.11 | v0.9        | v0.9   | v0.3        | ✅ (supports `rand_core` v0.6) |
+| v0.1 -> v0.9   | v0.6        | v0.8   | v0.2        | ❌                             |
 
 ## Migrations
 

--- a/bevy_prng/Cargo.toml
+++ b/bevy_prng/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 [features]
 default = []
 std = ["rand_chacha?/std"]
+bevy_reflect = ["dep:bevy_reflect"]
 serialize = [
     "dep:serde",
     "rand_core/serde",
@@ -29,7 +30,7 @@ rand_xoshiro = ["dep:rand_xoshiro"]
 compat = ["dep:rand_core_06"]
 
 [dependencies]
-bevy_reflect.workspace = true
+bevy_reflect = { workspace = true, optional = true }
 rand_core.workspace = true
 rand_core_06 = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/bevy_prng/README.md
+++ b/bevy_prng/README.md
@@ -69,7 +69,7 @@ The versions of `rand_core`/`rand` that `bevy_prng` is compatible with is as fol
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/bevy_prng/README.md
+++ b/bevy_prng/README.md
@@ -15,6 +15,7 @@ This crate is `no_std` compatible.
 
 By default, `bevy_prng` won't export anything _unless_ the feature/algorithm you require is explicitly defined. In order to gain access to a newtyped PRNG struct, you'll have activate one of the following features:
 
+- **`bevy_reflect`** - Enables reflection support for all `bevy_prng` types.
 - **`std`** - This enables some `std` specific functionality in some PRNGs, particularly in `rand_chacha`. Only for `std` environments.
 - **`rand_chacha`** - This enables the exporting of newtyped `ChaCha*Rng` structs, for those that want/need to use a CSPRNG level source.
 - **`rand_pcg`** - This enables the exporting of newtyped `Pcg*` structs from `rand_pcg`.
@@ -48,20 +49,21 @@ All the below crates implement the necessary traits to be compatible with `bevy_
 
 `bevy_prng` uses the same MSRV as `bevy`.
 
-| `bevy` | `bevy_prng`  |
-| ------ | ------------ |
-| v0.16  | v0.10        |
-| v0.15  | v0.8 -> v0.9 |
-| v0.14  | v0.7 -> v0.8 |
-| v0.13  | v0.5 -> v0.6 |
-| v0.12  | v0.2         |
-| v0.11  | v0.1         |
+| `bevy` | `bevy_prng`   |
+| ------ | ------------- |
+| v0.16  | v0.10 - v0.11 |
+| v0.15  | v0.8 - v0.9   |
+| v0.14  | v0.7 - v0.8   |
+| v0.13  | v0.5 - v0.6   |
+| v0.12  | v0.2          |
+| v0.11  | v0.1          |
 
 The versions of `rand_core`/`rand` that `bevy_prng` is compatible with is as follows:
 
-| `bevy_prng`   | `rand_core` | `rand` |
-| ------------- | ----------- | ------ |
-| v0.1 -> v0.10 | v0.6        | v0.8   |
+| `bevy_prng`    | `rand_core` | `rand` | `getrandom` | `compat` feature               |
+| -------------- | ----------- | ------ | ----------- | ------------------------------ |
+| v0.10 -> v0.11 | v0.9        | v0.9   | v0.3        | ✅ (supports `rand_core` v0.6) |
+| v0.1 -> v0.9   | v0.6        | v0.8   | v0.2        | ❌                             |
 
 ## License
 

--- a/bevy_prng/src/chacha.rs
+++ b/bevy_prng/src/chacha.rs
@@ -1,8 +1,9 @@
 use crate::newtype::newtype_prng;
 
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{Reflect, ReflectFromReflect};
 
-#[cfg(feature = "serialize")]
+#[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 newtype_prng!(

--- a/bevy_prng/src/newtype.rs
+++ b/bevy_prng/src/newtype.rs
@@ -1,22 +1,23 @@
 macro_rules! newtype_prng {
     ($newtype:tt, $rng:ty, $doc:tt, $feature:tt) => {
         #[doc = $doc]
-        #[derive(Debug, Clone, PartialEq, Reflect)]
-        #[reflect(opaque)]
+        #[derive(Debug, Clone, PartialEq)]
+        #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+        #[cfg_attr(feature = "bevy_reflect", reflect(opaque))]
         #[cfg_attr(
             feature = "serialize",
             derive(::serde::Serialize, ::serde::Deserialize)
         )]
         #[cfg_attr(
-            all(feature = "serialize"),
+            all(feature = "serialize", feature = "bevy_reflect"),
             reflect(opaque, Debug, PartialEq, FromReflect, Serialize, Deserialize)
         )]
         #[cfg_attr(
-            all(not(feature = "serialize")),
+            all(not(feature = "serialize"), feature = "bevy_reflect"),
             reflect(opaque, Debug, PartialEq, FromReflect)
         )]
         #[cfg_attr(docsrs, doc(cfg(feature = $feature)))]
-        #[type_path = "bevy_prng"]
+        #[cfg_attr(feature = "bevy_reflect", type_path = "bevy_prng")]
         #[repr(transparent)]
         pub struct $newtype($rng);
 

--- a/bevy_prng/src/newtype.rs
+++ b/bevy_prng/src/newtype.rs
@@ -101,25 +101,27 @@ macro_rules! newtype_prng {
     };
 }
 
-#[cfg(feature = "rand_xoshiro")]
+#[cfg(all(feature = "rand_xoshiro", feature = "bevy_reflect"))]
 macro_rules! newtype_prng_remote {
     ($newtype:tt, $rng:ty, $seed:ty, $doc:tt, $feature:tt) => {
         #[doc = $doc]
-        #[derive(Debug, Clone, PartialEq, Reflect)]
+        #[derive(Debug, Clone, PartialEq)]
+        #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+        #[cfg_attr(feature = "bevy_reflect", reflect(opaque))]
         #[cfg_attr(
             feature = "serialize",
             derive(::serde::Serialize, ::serde::Deserialize)
         )]
         #[cfg_attr(
-            all(feature = "serialize"),
+            all(feature = "serialize", feature = "bevy_reflect"),
             reflect(opaque, Debug, PartialEq, FromReflect, Serialize, Deserialize)
         )]
         #[cfg_attr(
-            all(not(feature = "serialize")),
+            all(not(feature = "serialize"), feature = "bevy_reflect"),
             reflect(opaque, Debug, PartialEq, FromReflect)
         )]
         #[cfg_attr(docsrs, doc(cfg(feature = $feature)))]
-        #[type_path = "bevy_prng"]
+        #[cfg_attr(feature = "bevy_reflect", type_path = "bevy_prng")]
         #[repr(transparent)]
         pub struct $newtype($rng);
 
@@ -204,5 +206,5 @@ macro_rules! newtype_prng_remote {
 }
 
 pub(crate) use newtype_prng;
-#[cfg(feature = "rand_xoshiro")]
+#[cfg(all(feature = "rand_xoshiro", feature = "bevy_reflect"))]
 pub(crate) use newtype_prng_remote;

--- a/bevy_prng/src/pcg.rs
+++ b/bevy_prng/src/pcg.rs
@@ -1,8 +1,9 @@
 use crate::newtype::newtype_prng;
 
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{Reflect, ReflectFromReflect};
 
-#[cfg(feature = "serialize")]
+#[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 newtype_prng!(

--- a/bevy_prng/src/wyrand.rs
+++ b/bevy_prng/src/wyrand.rs
@@ -1,8 +1,9 @@
 use crate::newtype::newtype_prng;
 
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{Reflect, ReflectFromReflect};
 
-#[cfg(feature = "serialize")]
+#[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 newtype_prng!(

--- a/bevy_prng/src/xoshiro.rs
+++ b/bevy_prng/src/xoshiro.rs
@@ -1,8 +1,9 @@
 use crate::newtype::{newtype_prng, newtype_prng_remote};
 
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{Reflect, ReflectFromReflect, reflect_remote, std_traits::ReflectDefault};
 
-#[cfg(feature = "serialize")]
+#[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 /// Remote reflected version of [`rand_xoshiro::Seed512`], needed to support

--- a/bevy_prng/src/xoshiro.rs
+++ b/bevy_prng/src/xoshiro.rs
@@ -1,4 +1,7 @@
-use crate::newtype::{newtype_prng, newtype_prng_remote};
+use crate::newtype::newtype_prng;
+
+#[cfg(feature = "bevy_reflect")]
+use crate::newtype::newtype_prng_remote;
 
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{Reflect, ReflectFromReflect, reflect_remote, std_traits::ReflectDefault};
@@ -6,25 +9,29 @@ use bevy_reflect::{Reflect, ReflectFromReflect, reflect_remote, std_traits::Refl
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
+#[cfg(feature = "bevy_reflect")]
 /// Remote reflected version of [`rand_xoshiro::Seed512`], needed to support
 /// proper reflection for the 512 bit variants of the Xoshiro PRNG.
-#[reflect_remote(::rand_xoshiro::Seed512)]
+#[cfg_attr(feature = "bevy_reflect", reflect_remote(::rand_xoshiro::Seed512))]
 #[derive(Debug, Default, Clone)]
 #[reflect(Debug, Default)]
 pub struct Seed512(pub [u8; 64]);
 
+#[cfg(feature = "bevy_reflect")]
 impl AsRef<[u8]> for Seed512 {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
 }
 
+#[cfg(feature = "bevy_reflect")]
 impl AsMut<[u8]> for Seed512 {
     fn as_mut(&mut self) -> &mut [u8] {
         self.0.as_mut()
     }
 }
 
+#[cfg(feature = "bevy_reflect")]
 newtype_prng_remote!(
     Xoshiro512StarStar,
     ::rand_xoshiro::Xoshiro512StarStar,
@@ -33,6 +40,15 @@ newtype_prng_remote!(
     "rand_xoshiro"
 );
 
+#[cfg(not(feature = "bevy_reflect"))]
+newtype_prng!(
+    Xoshiro512StarStar,
+    ::rand_xoshiro::Xoshiro512StarStar,
+    "A newtyped [`rand_xoshiro::Xoshiro512StarStar`] RNG",
+    "rand_xoshiro"
+);
+
+#[cfg(feature = "bevy_reflect")]
 newtype_prng_remote!(
     Xoshiro512PlusPlus,
     ::rand_xoshiro::Xoshiro512PlusPlus,
@@ -41,10 +57,27 @@ newtype_prng_remote!(
     "rand_xoshiro"
 );
 
+#[cfg(not(feature = "bevy_reflect"))]
+newtype_prng!(
+    Xoshiro512PlusPlus,
+    ::rand_xoshiro::Xoshiro512PlusPlus,
+    "A newtyped [`rand_xoshiro::Xoshiro512PlusPlus`] RNG",
+    "rand_xoshiro"
+);
+
+#[cfg(feature = "bevy_reflect")]
 newtype_prng_remote!(
     Xoshiro512Plus,
     ::rand_xoshiro::Xoshiro512Plus,
     Seed512,
+    "A newtyped [`rand_xoshiro::Xoshiro512Plus`] RNG",
+    "rand_xoshiro"
+);
+
+#[cfg(not(feature = "bevy_reflect"))]
+newtype_prng!(
+    Xoshiro512Plus,
+    ::rand_xoshiro::Xoshiro512Plus,
     "A newtyped [`rand_xoshiro::Xoshiro512Plus`] RNG",
     "rand_xoshiro"
 );

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,4 @@
 use core::{
-    fmt::Debug,
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
@@ -89,19 +88,14 @@ pub trait RngCommandsExt {
     fn rng_entity<Rng: EntropySource>(
         &mut self,
         entity: &RngEntityItem<'_, Rng>,
-    ) -> RngEntityCommands<'_, Rng>
-    where
-        Rng::Seed: Debug + Clone + Send + Sync;
+    ) -> RngEntityCommands<'_, Rng>;
 }
 
 impl RngCommandsExt for Commands<'_, '_> {
     fn rng_entity<Rng: EntropySource>(
         &mut self,
         entity: &RngEntityItem<'_, Rng>,
-    ) -> RngEntityCommands<'_, Rng>
-    where
-        Rng::Seed: Debug + Clone + Send + Sync,
-    {
+    ) -> RngEntityCommands<'_, Rng> {
         self.entity(entity.entity()).rng()
     }
 }

--- a/src/global.rs
+++ b/src/global.rs
@@ -34,28 +34,19 @@ pub type GlobalEntropy<'w, T> = Single<'w, &'static mut Entropy<T>, With<Global>
 /// }
 /// ```
 #[derive(SystemParam)]
-pub struct GlobalRngEntity<'w, 's, Rng: EntropySource>
-where
-    Rng::Seed: Debug + Clone + Send + Sync,
-{
+pub struct GlobalRngEntity<'w, 's, Rng: EntropySource> {
     commands: Commands<'w, 's>,
     data: Single<'w, RngEntity<Rng>, With<Global>>,
 }
 
-impl<Rng: EntropySource> GlobalRngEntity<'_, '_, Rng>
-where
-    Rng::Seed: Debug + Send + Sync + Clone,
-{
+impl<Rng: EntropySource> GlobalRngEntity<'_, '_, Rng> {
     /// Creates a [`Global`]'s [`RngEntityCommands`].
     pub fn rng_commands(&mut self) -> RngEntityCommands<'_, Rng> {
         self.commands.entity(self.data.entity()).rng()
     }
 }
 
-impl<'w, Rng: EntropySource> Deref for GlobalRngEntity<'w, '_, Rng>
-where
-    Rng::Seed: Debug + Clone + Send + Sync,
-{
+impl<'w, Rng: EntropySource> Deref for GlobalRngEntity<'w, '_, Rng> {
     type Target = RngEntityItem<'w, Rng>;
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ extern crate std;
 
 /// Command extensions for relating groups of RNGs.
 pub mod commands;
-/// Components for integrating [`RngCore`] PRNGs into bevy. Must be newtyped to support [`Reflect`].
+/// Components for integrating [`rand_core::RngCore`] PRNGs into bevy. Must be newtyped to support [`bevy_reflect::Reflect`].
 pub mod component;
 /// Global [`crate::component::Entropy`] sources, with query helpers.
 pub mod global;
@@ -21,15 +21,15 @@ pub mod global;
 pub mod observers;
 /// Utility query/system parameters for accessing RNGs.
 pub mod params;
-/// Plugin for integrating [`RngCore`] PRNGs into bevy. Must be newtyped to support [`Reflect`].
+/// Plugin for integrating [`rand_core::RngCore`] PRNGs into bevy. Must be newtyped to support [`bevy_reflect::Reflect`].
 pub mod plugin;
 /// Prelude for providing all necessary types for easy use.
 pub mod prelude;
-/// Seed Resource for seeding [`crate::resource::GlobalEntropy`].
+/// Seed Components for seeding [`crate::component::Entropy`].
 pub mod seed;
 #[cfg(feature = "thread_local_entropy")]
 mod thread_local_entropy;
-/// Traits for enabling utility methods for [`crate::component::Entropy`] and [`crate::resource::GlobalEntropy`].
+/// Traits for enabling utility methods for [`crate::component::Entropy`].
 pub mod traits;
 #[cfg(doc)]
 pub mod tutorial;

--- a/src/observers.rs
+++ b/src/observers.rs
@@ -143,10 +143,7 @@ pub fn seed_from_global<Source: EntropySource, Target: EntropySource>(
     trigger: Trigger<SeedFromGlobal<Source, Target>>,
     mut source: GlobalEntropy<Source>,
     mut commands: Commands,
-) where
-    Source::Seed: Send + Sync + Clone,
-    Target::Seed: Send + Sync + Clone,
-{
+) {
     if let Ok(mut entity) = commands.get_entity(trigger.target()) {
         entity.insert(source.fork_as_seed::<Target>());
     }
@@ -159,10 +156,7 @@ pub fn seed_from_parent<Source: EntropySource, Target: EntropySource>(
     q_linked: Query<&RngSource<Source, Target>>,
     mut q_parents: Query<&mut Entropy<Source>, With<RngLinks<Source, Target>>>,
     mut commands: Commands,
-) where
-    Source::Seed: Send + Sync + Clone,
-    Target::Seed: Send + Sync + Clone,
-{
+) {
     let target = trigger.target();
 
     if let Ok(rng) = q_linked
@@ -181,10 +175,7 @@ pub fn seed_linked<Source: EntropySource, Target: EntropySource>(
     trigger: Trigger<SeedLinked<Source, Target>>,
     mut q_source: Query<(&mut Entropy<Source>, &RngLinks<Source, Target>)>,
     mut commands: Commands,
-) where
-    Source::Seed: Send + Sync + Clone,
-    Target::Seed: Send + Sync + Clone,
-{
+) {
     if let Ok((mut rng, targets)) = q_source.get_mut(trigger.target()) {
         let batched: Vec<_> = targets
             .0
@@ -203,10 +194,7 @@ pub fn trigger_seed_linked<Source: EntropySource, Target: EntropySource>(
     trigger: Trigger<OnInsert, Entropy<Source>>,
     q_source: Query<RngEntity<Source>, With<RngLinks<Source, Target>>>,
     mut commands: Commands,
-) where
-    Source::Seed: Debug + Send + Sync + Clone,
-    Target::Seed: Debug + Send + Sync + Clone,
-{
+) {
     // Check whether the triggered entity is a source entity. If not, do nothing otherwise we
     // will keep triggering and cause a stack overflow.
     if let Ok(mut rng_source) = q_source

--- a/src/params.rs
+++ b/src/params.rs
@@ -8,18 +8,12 @@ use crate::{seed::RngSeed, traits::SeedSource};
 /// A smart query data wrapper that selects for entities that match the `Rng` type,
 /// returning read-only data for the seed and the entity.
 #[derive(Debug, QueryData)]
-pub struct RngEntity<Rng: EntropySource>
-where
-    Rng::Seed: Debug + Clone + Send + Sync,
-{
+pub struct RngEntity<Rng: EntropySource> {
     seed: &'static RngSeed<Rng>,
     entity: Entity,
 }
 
-impl<Rng: EntropySource> RngEntityItem<'_, Rng>
-where
-    Rng::Seed: Debug + Clone,
-{
+impl<Rng: EntropySource> RngEntityItem<'_, Rng> {
     /// Return the [`Entity`] of the data
     #[inline]
     pub fn entity(&self) -> Entity {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,6 +1,6 @@
-use core::{fmt::Debug, marker::PhantomData};
+use core::marker::PhantomData;
 
-use crate::{component::Entropy, global::Global, seed::RngSeed, traits::SeedSource};
+use crate::{global::Global, seed::RngSeed, traits::SeedSource};
 use bevy_app::{App, Plugin};
 use bevy_prng::{EntropySeed, EntropySource};
 
@@ -33,10 +33,7 @@ pub struct EntropyPlugin<Rng: EntropySource + 'static> {
     seed: Option<Rng::Seed>,
 }
 
-impl<Rng: EntropySource + 'static> EntropyPlugin<Rng>
-where
-    Rng::Seed: Send + Sync + Clone,
-{
+impl<Rng: EntropySource + 'static> EntropyPlugin<Rng> {
     /// Creates a new plugin instance configured for randomised,
     /// non-deterministic seeding of the global entropy resource.
     #[inline]
@@ -53,10 +50,7 @@ where
     }
 }
 
-impl<Rng: EntropySource + 'static> Default for EntropyPlugin<Rng>
-where
-    Rng::Seed: Send + Sync + Clone,
-{
+impl<Rng: EntropySource + 'static> Default for EntropyPlugin<Rng> {
     fn default() -> Self {
         Self::new()
     }
@@ -67,7 +61,8 @@ where
     Rng::Seed: EntropySeed,
 {
     fn build(&self, app: &mut App) {
-        app.register_type::<Entropy<Rng>>()
+        #[cfg(feature = "bevy_reflect")]
+        app.register_type::<crate::component::Entropy<Rng>>()
             .register_type::<RngSeed<Rng>>()
             .register_type::<Rng::Seed>();
 
@@ -127,10 +122,8 @@ impl<Source: EntropySource, Target: EntropySource> Default
     }
 }
 
-impl<Source: EntropySource, Target: EntropySource> Plugin for EntropyRelationsPlugin<Source, Target>
-where
-    Source::Seed: Debug + Send + Sync + Clone,
-    Target::Seed: Debug + Send + Sync + Clone,
+impl<Source: EntropySource, Target: EntropySource> Plugin
+    for EntropyRelationsPlugin<Source, Target>
 {
     fn build(&self, app: &mut App) {
         let world = app.world_mut();

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -24,7 +24,14 @@ pub use bevy_prng::{Pcg32, Pcg64, Pcg64Mcg};
 #[cfg(feature = "rand_xoshiro")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_xoshiro")))]
 pub use bevy_prng::{
-    Seed512, Xoroshiro64Star, Xoroshiro64StarStar, Xoroshiro128Plus, Xoroshiro128PlusPlus,
+    Xoroshiro64Star, Xoroshiro64StarStar, Xoroshiro128Plus, Xoroshiro128PlusPlus,
     Xoroshiro128StarStar, Xoshiro128Plus, Xoshiro128PlusPlus, Xoshiro128StarStar, Xoshiro256Plus,
     Xoshiro256PlusPlus, Xoshiro256StarStar, Xoshiro512Plus, Xoshiro512PlusPlus, Xoshiro512StarStar,
 };
+
+#[cfg(all(feature = "rand_xoshiro", feature = "bevy_reflect"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "rand_xoshiro", feature = "rand_xoshiro")))
+)]
+pub use bevy_prng::Seed512;

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -5,6 +5,7 @@ use bevy_ecs::{
     prelude::Component,
 };
 use bevy_prng::EntropySource;
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 use rand_core::SeedableRng;
 
@@ -34,10 +35,11 @@ use crate::{component::Entropy, traits::SeedSource};
 ///         ));
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Reflect)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct RngSeed<R: EntropySource> {
     seed: R::Seed,
-    #[reflect(ignore)]
+    #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
     rng: PhantomData<R>,
 }
 
@@ -65,7 +67,7 @@ where
     }
 }
 
-impl<R: EntropySource> Component for RngSeed<R>
+impl<R: EntropySource + 'static> Component for RngSeed<R>
 where
     R::Seed: Sync + Send + Clone,
 {
@@ -124,7 +126,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "serialize")]
+    #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
     #[test]
     fn reflection_serialization_round_trip_works() {
         use super::*;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -108,10 +108,7 @@ pub trait ForkableInnerRng: EcsEntropy {
 /// Trait for implementing forking behaviour for [`crate::component::Entropy`].
 /// Forking creates a new RNG instance using a generated seed from the original source. If the original is seeded with a known
 /// seed, this process is deterministic. This trait enables forking from an entropy source to a seed component.
-pub trait ForkableSeed<S: EntropySource>: EcsEntropy
-where
-    S::Seed: Send + Sync + Clone,
-{
+pub trait ForkableSeed<S: EntropySource>: EcsEntropy {
     /// The type of seed component that is to be forked from the original source.
     type Output: SeedSource<S>;
 
@@ -151,8 +148,7 @@ pub trait ForkableAsSeed<S: EntropySource>: EcsEntropy {
     /// The type of seed component that is to be forked from the original source.
     type Output<T>: SeedSource<T>
     where
-        T: EntropySource,
-        T::Seed: Send + Sync + Clone;
+        T: EntropySource;
 
     /// Fork a new seed from the original entropy source.
     /// This method allows one to specify the RNG algorithm to be used for the forked seed.
@@ -173,10 +169,7 @@ pub trait ForkableAsSeed<S: EntropySource>: EcsEntropy {
     /// }
     /// ```
     #[inline]
-    fn fork_as_seed<T: EntropySource>(&mut self) -> Self::Output<T>
-    where
-        T::Seed: Send + Sync + Clone,
-    {
+    fn fork_as_seed<T: EntropySource>(&mut self) -> Self::Output<T> {
         let mut seed = T::Seed::default();
 
         self.fill_bytes(seed.as_mut());
@@ -188,10 +181,7 @@ pub trait ForkableAsSeed<S: EntropySource>: EcsEntropy {
 /// Trait for implementing forking behaviour for [`crate::component::Entropy`].
 /// Forking creates a new RNG instance using a generated seed from the original source. If the original is seeded with a known
 /// seed, this process is deterministic. This trait enables forking from an entropy source to the RNG's seed type.
-pub trait ForkableInnerSeed<S: EntropySource>: EcsEntropy
-where
-    S::Seed: Send + Sync + Clone + AsMut<[u8]> + Default,
-{
+pub trait ForkableInnerSeed<S: EntropySource>: EcsEntropy {
     /// The type of seed component that is to be forked from the original source.
     type Output: Send + Sync + Clone + AsMut<[u8]> + Default;
 
@@ -225,10 +215,7 @@ where
 
 /// A trait for providing [`crate::seed::RngSeed`] with
 /// common initialization strategies. This trait is not object safe and is also a sealed trait.
-pub trait SeedSource<R: EntropySource>: private::SealedSeed<R>
-where
-    R::Seed: Send + Sync + Clone,
-{
+pub trait SeedSource<R: EntropySource>: private::SealedSeed<R> {
     /// Initialize a [`SeedSource`] from a given `seed` value.
     fn from_seed(seed: R::Seed) -> Self;
 

--- a/tutorial/01-choosing-prng.md
+++ b/tutorial/01-choosing-prng.md
@@ -7,7 +7,7 @@ If you need a TL;DR of this section, then select `wyrand` for the fastest PRNG w
 All supported PRNGs and compatible structs are provided by the `bevy_prng` crate. Simply activate the relevant features in `bevy_rand`/`bevy_prng` to pull in the PRNG algorithm you want to use, and then import them like so:
 
 ```toml
-bevy_rand = { version = "0.10", features = ["rand_chacha", "wyrand"] }
+bevy_rand = { version = "0.11", features = ["rand_chacha", "wyrand"] }
 ```
 ```rust ignore
 use bevy::prelude::*;
@@ -15,8 +15,8 @@ use bevy_rand::prelude::{ChaCha8Rng, WyRand};
 ```
 or
 ```toml
-bevy_rand = "0.10"
-bevy_prng = { version = "0.10", features = ["rand_chacha", "wyrand"] }
+bevy_rand = "0.11"
+bevy_prng = { version = "0.11", features = ["rand_chacha", "wyrand"] }
 ```
 ```rust ignore
 use bevy::prelude::*;


### PR DESCRIPTION
A small refactor of trait constraints and requirements across `bevy_prng` and `bevy_rand`, to clean up some implementations across the board and to enable optional `bevy_reflect` support, so to improve the `no_std` support story (since reflection imposes quite a bit of `alloc` overhead, which while fine for more capable hardware, is a bit much for more resource constrained platforms such as embedded boards and old console hardware like the GBA).

This is a breaking change which will require a new major version due to differences in what deps are enabled when default features is false. Otherwise, this will be a straightforward upgrade.