### PR TITLE
refactor: Update for latest Event Rearchitecture changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 [[package]]
 name = "bevy_app"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -95,7 +95,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_ecs_macros",
  "bevy_platform",
@@ -120,7 +120,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -131,7 +131,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -143,7 +143,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "critical-section",
  "foldhash",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 
 [[package]]
 name = "bevy_rand"
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -243,7 +243,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -256,7 +256,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "async-channel",
  "async-task",
@@ -272,7 +272,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_platform",
  "disqualified",
@@ -508,7 +508,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.4+wasi-0.2.4",
+ "wasi 0.14.5+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1000,9 +1000,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-xid"
@@ -1057,9 +1057,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.4+wasi-0.2.4"
+version = "0.14.5+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
  "wit-bindgen",
 ]

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -132,3 +132,21 @@ use rand_core::RngCore;
     println!("Random value: {}", rng.next_u32());
 }
 ```
+
+Due to the Event Rearchitecture, `RngEntityCommands` was reworked to use `Commands` instead of `EntityCommands`, and `RngCommandsExt` has been merged into `RngEntityCommandsExt`. So for getting a `RngEntityCommands`, the changes you need to make are as follows:
+
+```diff
+use bevy_ecs::prelude::*;
+use bevy_prng::WyRand;
+use bevy_rand::prelude::*;
+
+#[derive(Component)]
+struct Target;
+
+fn intialise_rng_entities(mut commands: Commands, mut q_targets: Query<Entity, With<Target>>) {
+    for target in &q_targets {
+-       commands.entity(target).rng::<WyRand>().reseed_from_os_rng();
++       commands.rng::<WyRand>(target).reseed_from_os_rng();
+    }
+}
+```

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 [[package]]
 name = "bevy"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_internal",
 ]
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "bevy_android"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "android-activity",
 ]
@@ -317,7 +317,7 @@ dependencies = [
 [[package]]
 name = "bevy_anti_alias"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -399,7 +399,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -410,7 +410,7 @@ dependencies = [
 [[package]]
 name = "bevy_camera"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -450,7 +450,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "atomic-waker",
  "bevy_app",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_a11y",
  "bevy_android",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "bevy_light"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -756,7 +756,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -786,7 +786,7 @@ checksum = "7ef8e4b7e61dfe7719bb03c884dc270cd46a82efb40f93e9933b990c5c190c59"
 [[package]]
 name = "bevy_pbr"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "critical-section",
  "foldhash 0.2.0",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 
 [[package]]
 name = "bevy_rand"
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -934,7 +934,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -982,7 +982,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -993,7 +993,7 @@ dependencies = [
 [[package]]
 name = "bevy_shader"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_asset",
  "bevy_platform",
@@ -1009,7 +1009,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1032,7 +1032,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite_render"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1080,7 +1080,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui_render"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_platform",
  "disqualified",
@@ -1206,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1222,7 +1222,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.17.0-dev"
-source = "git+https://github.com/bevyengine/bevy#ec735b9649e21e70cf240c15bb2a95e92b242b08"
+source = "git+https://github.com/bevyengine/bevy#657f71b6e6880746ed09dcdea5dacad118dfc87e"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -1951,7 +1951,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
 dependencies = [
- "rustix 1.1.1",
+ "rustix 1.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -2296,12 +2296,6 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2874,7 +2868,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.1",
+ "rustix 1.1.2",
  "windows-sys 0.60.2",
 ]
 
@@ -3146,15 +3140,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9621e389a110cae094269936383d69b869492f03e5c1ed2d575a53c029d4441d"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "linux-raw-sys 0.9.4",
  "windows-sys 0.61.0",
 ]
 
@@ -3697,9 +3690,9 @@ checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-linebreak"
@@ -3784,9 +3777,18 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.14.4+wasi-0.2.4"
+version = "0.14.5+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
  "wit-bindgen",
 ]
@@ -3871,7 +3873,7 @@ checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs 1.2.1",
- "rustix 1.1.1",
+ "rustix 1.1.2",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -3884,7 +3886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
  "bitflags 2.9.4",
- "rustix 1.1.1",
+ "rustix 1.1.2",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -3906,7 +3908,7 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
 dependencies = [
- "rustix 1.1.1",
+ "rustix 1.1.2",
  "wayland-client",
  "xcursor",
 ]
@@ -4658,7 +4660,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix 1.1.1",
+ "rustix 1.1.2",
  "x11rb-protocol",
 ]
 

--- a/src/global.rs
+++ b/src/global.rs
@@ -37,8 +37,8 @@ pub struct GlobalRngEntity<'w, 's, Rng: EntropySource> {
 
 impl<Rng: EntropySource> GlobalRngEntity<'_, '_, Rng> {
     /// Creates a [`GlobalRng`]'s [`RngEntityCommands`].
-    pub fn rng_commands(&mut self) -> RngEntityCommands<'_, Rng> {
-        self.commands.entity(self.data.entity()).rng()
+    pub fn rng_commands(&mut self) -> RngEntityCommands<'_, '_, Rng> {
+        self.commands.rng(self.data.entity())
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use crate::commands::{RngCommandsExt, RngEntityCommands, RngEntityCommandsExt};
+pub use crate::commands::{RngEntityCommands, RngEntityCommandsExt};
 pub use crate::component::Entropy;
 pub use crate::global::{GlobalRng, GlobalRngEntity};
 pub use crate::observers::{RngLinks, RngSource, SeedFromGlobal, SeedFromSource, SeedLinked};

--- a/tests/integration/reseeding.rs
+++ b/tests/integration/reseeding.rs
@@ -226,7 +226,7 @@ pub fn observer_global_reseeding() {
 pub fn generic_observer_reseeding_from_parent() {
     use bevy_app::prelude::{PostUpdate, PreUpdate, Startup};
     use bevy_ecs::prelude::With;
-    use bevy_rand::{commands::RngCommandsExt, seed::RngSeed, traits::SeedSource};
+    use bevy_rand::{commands::RngEntityCommandsExt, seed::RngSeed, traits::SeedSource};
 
     let seed = [2u8; 8];
 
@@ -291,7 +291,7 @@ pub fn generic_observer_reseeding_from_parent() {
 pub fn generic_observer_reseeding_children() {
     use bevy_app::prelude::{Last, PostUpdate, PreUpdate, Startup};
     use bevy_ecs::prelude::{Component, With, Without};
-    use bevy_rand::{commands::RngCommandsExt, seed::RngSeed, traits::SeedSource};
+    use bevy_rand::{commands::RngEntityCommandsExt, seed::RngSeed, traits::SeedSource};
 
     let seed = [2u8; 8];
 

--- a/tutorial/04-seeding.md
+++ b/tutorial/04-seeding.md
@@ -97,7 +97,7 @@ Reinsertions do not invoke archetype moves, so this will not cause any extra ove
 ```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::prelude::{Entropy, GlobalRng, RngEntity, RngCommandsExt};
+use bevy_rand::prelude::{Entropy, GlobalRng, RngEntity, RngEntityCommandsExt};
 use rand::Rng;
 
 #[derive(Component)]

--- a/tutorial/05-observer-driven-reseeding.md
+++ b/tutorial/05-observer-driven-reseeding.md
@@ -74,7 +74,7 @@ fn intialise_rng_entities_with_set_seed(mut commands: Commands, mut q_targets: Q
     let seed = u64::to_ne_bytes(42); 
 
     for target in &q_targets {
-        commands.entity(target).rng::<WyRand>().reseed(seed);
+        commands.rng::<WyRand>(target).reseed(seed);
     }
 }
 ```
@@ -90,7 +90,7 @@ Once the relations are created, it becomes easy to pull new seeds from sources/g
 ```rust
 use bevy_ecs::prelude::*;
 use bevy_prng::WyRand;
-use bevy_rand::prelude::{RngEntity, RngCommandsExt};
+use bevy_rand::prelude::{RngEntity, RngEntityCommandsExt};
 
 #[derive(Component)]
 struct Source;
@@ -131,7 +131,7 @@ fn initial_setup(mut commands: Commands) {
 
     // Initialise the Source entity to be an RNG source and then seed all its
     // linked entities.
-    commands.trigger_targets(SeedFromGlobal::<WyRand, WyRand>::default(), source);
+    commands.trigger_targets(SeedFromGlobal::<WyRand, WyRand>::new(source));
 }
 ```
 
@@ -150,7 +150,7 @@ struct Target;
 
 fn pull_seed_from_parent(mut commands: Commands, mut q_targets: Query<Entity, With<Target>>) {
     for target in &q_targets {
-        commands.trigger_targets(SeedFromSource::<WyRand, WyRand>::default(), target);
+        commands.trigger_targets(SeedFromSource::<WyRand, WyRand>::new(target));
     }
 }
 ```


### PR DESCRIPTION
With https://github.com/bevyengine/bevy/pull/20731 merged to main, there's breaking changes on how events are handled, and with `bevy_rand`, that relates to the observer code in place. So this PR is a fairly quick refactor to just bring things in line with the new changes, and as a result, simplify a couple of bits.

Most of the breaking changes here are internal, so users won't be exposed to too much churn unless they are doing things much more... manually. The important breaking public API changes have been documented in the MIGRATION guide.