### PR TITLE
Configure getrandom for Web WASM in `bevy_prng`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - main
       - v0.16
       - v0.17
+      - v0.18
 
 env:
   RUSTFLAGS: -D warnings
@@ -49,7 +50,7 @@ jobs:
         run: wasm-pack test --headless --chrome --firefox -- --locked --all-features
         if: startsWith(matrix.os, 'ubuntu')
       - name: Test wasm (no default features)
-        run: wasm-pack test --headless --chrome --firefox -- --locked --no-default-features
+        run: wasm-pack test --headless --chrome --firefox -- --locked --no-default-features --features wasm_js
         if: startsWith(matrix.os, 'ubuntu')
   miri:
     name: "Miri"
@@ -77,7 +78,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: get MSRV
         run: |
-          msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="wyrand") | .rust_version'`
+          msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy_rand") | .rust_version'`
           echo "MSRV=$msrv" >> $GITHUB_ENV
       - name: Install Rust
         run: rustup update ${{ env.MSRV }} --no-self-update && rustup default ${{ env.MSRV }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_reflect",
  "chacha20",
- "getrandom 0.2.17",
- "getrandom 0.3.4",
- "getrandom 0.4.1",
+ "getrandom",
  "rand_core 0.10.0",
  "rand_core 0.6.4",
  "rand_core 0.9.5",
@@ -233,7 +231,7 @@ dependencies = [
  "bevy_math",
  "bevy_prng",
  "bevy_reflect",
- "getrandom 0.4.1",
+ "getrandom",
  "rand",
  "rand_core 0.10.0",
  "rand_core 0.6.4",
@@ -577,33 +575,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
@@ -877,7 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
- "getrandom 0.4.1",
+ "getrandom",
  "rand_core 0.10.0",
 ]
 
@@ -1156,7 +1127,7 @@ version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -1188,12 +1159,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,11 +202,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_prng"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bevy_ecs",
  "bevy_reflect",
  "chacha20",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "getrandom 0.4.1",
  "rand_core 0.10.0",
  "rand_core 0.6.4",
@@ -224,14 +226,13 @@ source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606
 
 [[package]]
 name = "bevy_rand"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_math",
  "bevy_prng",
  "bevy_reflect",
- "getrandom 0.2.17",
  "getrandom 0.4.1",
  "rand",
  "rand_core 0.10.0",
@@ -584,6 +585,20 @@ dependencies = [
  "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 [[package]]
 name = "bevy_app"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "approx",
  "arrayvec",
@@ -184,7 +184,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "critical-section",
  "foldhash 0.2.0",
@@ -222,7 +222,7 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 
 [[package]]
 name = "bevy_rand"
@@ -246,7 +246,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -272,7 +272,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "async-channel",
  "async-task",
@@ -301,7 +301,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#7c153070c018db5f606f59eb6b04963df7b56ed6"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_platform",
  "disqualified",
@@ -710,9 +710,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1215,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1228,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1242,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1252,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1265,18 +1265,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.58"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45649196a53b0b7a15101d845d44d2dda7374fc1b5b5e2bbf58b7577ff4b346d"
+checksum = "6f9483e929b4ae6889bc7c62b314abda7d0bd286a8d82b21235855d5327e4eb4"
 dependencies = [
  "async-trait",
  "cast",
@@ -1296,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.58"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f579cdd0123ac74b94e1a4a72bd963cf30ebac343f2df347da0b8df24cdebed2"
+checksum = "30f8b972c5c33f97917c9f418535f3175e464d48db15f5226d124c648a1b4036"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1307,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
+checksum = "0000397743a3b549ddba01befd1a26020eff98a028429630281c4203b4cc538d"
 
 [[package]]
 name = "wasm-encoder"
@@ -1347,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "wyrand"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24a385d18bdb8db40f079c98c76839d9f694a65f03d42ee561e6d56a2b2bb6e"
+checksum = "b5484c3d24f0e2e117d30bce6f8792e193be33e2b6e0b3f8945ccf265c56c6da"
 dependencies = [
  "rand_core 0.10.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,7 @@ chacha20 = { version = "0.10.0", default-features = false }
 wyrand = { version = "0.4" }
 rand_pcg = "0.10.0"
 rand_xoshiro = "0.8.0"
-getrandom = { version = "0.4.0", features = ["sys_rng"] }
-getrandom_02 = { version = "0.2", package = "getrandom" }
-getrandom_03 = { version = "0.3.4", package = "getrandom" }
+getrandom = { version = "0.4.0", default-features = false, features = ["sys_rng"] }
 
 [package]
 name = "bevy_rand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 repository = "https://github.com/Bluefinger/bevy_rand"
 license = "MIT OR Apache-2.0"
 version = "0.14.1"
-rust-version = "1.87.0"
+rust-version = "1.89.0"
 
 [workspace.dependencies]
 bevy_app = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 edition = "2024"
 repository = "https://github.com/Bluefinger/bevy_rand"
 license = "MIT OR Apache-2.0"
-version = "0.14.0"
+version = "0.14.1"
 rust-version = "1.87.0"
 
 [workspace.dependencies]
@@ -24,6 +24,8 @@ wyrand = { version = "0.4" }
 rand_pcg = "0.10.0"
 rand_xoshiro = "0.8.0"
 getrandom = { version = "0.4.0", features = ["sys_rng"] }
+getrandom_02 = { version = "0.2", package = "getrandom" }
+getrandom_03 = { version = "0.3.4", package = "getrandom" }
 
 [package]
 name = "bevy_rand"
@@ -61,7 +63,7 @@ chacha20 = ["bevy_prng/chacha20"]
 rand_pcg = ["bevy_prng/rand_pcg"]
 rand_xoshiro = ["bevy_prng/rand_xoshiro"]
 wyrand = ["bevy_prng/wyrand"]
-wasm_js = ["getrandom/wasm_js"]
+wasm_js = ["bevy_prng/wasm_js"]
 
 [dependencies]
 bevy_app.workspace = true
@@ -96,8 +98,6 @@ serde = { workspace = true }
 
 [target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
-getrandom = { version = "0.4.0", features = ["wasm_js"] }
-getrandom_02 = { version = "0.2", features = ["js"], package = "getrandom" }
 bevy_ecs = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
     "bevy_reflect",
 ] }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,16 @@ bevy_rand = { version = "0.14", features = ["wasm_js"] }
 
 This enables the `wasm_js` backend to be made available for `getrandom`, which will allow `bevy_rand` to compile correctly for web WASM environments. The reason for this is that `wasm32-unknown-unknown` is itself not actually a web target, so to actually target a web environment, we must specify the feature in order to activate `wasm-bindgen` to do its thing.
 
-If you have older versions of `getrandom` in your dep tree, enabling the `wasm_js` feature on `bevy_rand` should be enough to have these versions configured to work for Web WASM.
+If you have older versions of `getrandom` in your dep tree that are getting compiled in, then you might need to add further configuration to your `Cargo.toml` in order to enable Web WASM builds to compile correctly:
+
+```toml
+[target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
+bevy_rand = { version = "0.14", features = ["wasm_js"] }
+# Add the line below to make v0.3.4 getrandom work in Web WASM builds
+getrandom_03 = { version = "0.3.4", features = ["wasm_js"], package = "getrandom" }
+# Add the line below to make v0.2.17 getrandom work in Web WASM builds
+getrandom_02 = { version = "0.2.17", features = ["js"], package = "getrandom" }
+```
 
 ### Registering a PRNG for use with Bevy Rand
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ bevy_rand = { version = "0.14", features = ["wasm_js"] }
 
 This enables the `wasm_js` backend to be made available for `getrandom`, which will allow `bevy_rand` to compile correctly for web WASM environments. The reason for this is that `wasm32-unknown-unknown` is itself not actually a web target, so to actually target a web environment, we must specify the feature in order to activate `wasm-bindgen` to do its thing.
 
+If you have older versions of `getrandom` in your dep tree, enabling the `wasm_js` feature on `bevy_rand` should be enough to have these versions configured to work for Web WASM.
+
 ### Registering a PRNG for use with Bevy Rand
 
 Before a PRNG can be used via `GlobalEntropy` or `Entropy`, it must be registered via the plugin.

--- a/bevy_prng/Cargo.toml
+++ b/bevy_prng/Cargo.toml
@@ -26,8 +26,9 @@ chacha20 = ["dep:chacha20"]
 wyrand = ["dep:wyrand"]
 rand_pcg = ["dep:rand_pcg"]
 rand_xoshiro = ["dep:rand_xoshiro"]
-compat_09 = ["dep:rand_core_09"]
-compat_06 = ["dep:rand_core_06"]
+compat_09 = ["dep:rand_core_09", "dep:getrandom_03"]
+compat_06 = ["dep:rand_core_06", "dep:getrandom_02"]
+wasm_js = ["getrandom/wasm_js", "getrandom_03?/wasm_js", "getrandom_02?/js"]
 
 [dependencies]
 getrandom = { workspace = true }
@@ -36,6 +37,8 @@ bevy_reflect = { workspace = true, optional = true }
 rand_core.workspace = true
 rand_core_09 = { workspace = true, optional = true }
 rand_core_06 = { workspace = true, optional = true }
+getrandom_02 = { workspace = true, optional = true }
+getrandom_03 = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 chacha20 = { workspace = true, optional = true, features = ["rng"] }
 wyrand = { workspace = true, optional = true }

--- a/bevy_prng/Cargo.toml
+++ b/bevy_prng/Cargo.toml
@@ -26,9 +26,9 @@ chacha20 = ["dep:chacha20"]
 wyrand = ["dep:wyrand"]
 rand_pcg = ["dep:rand_pcg"]
 rand_xoshiro = ["dep:rand_xoshiro"]
-compat_09 = ["dep:rand_core_09", "dep:getrandom_03"]
-compat_06 = ["dep:rand_core_06", "dep:getrandom_02"]
-wasm_js = ["getrandom/wasm_js", "getrandom_03?/wasm_js", "getrandom_02?/js"]
+compat_09 = ["dep:rand_core_09"]
+compat_06 = ["dep:rand_core_06"]
+wasm_js = ["getrandom/wasm_js"]
 
 [dependencies]
 getrandom = { workspace = true }
@@ -37,8 +37,6 @@ bevy_reflect = { workspace = true, optional = true }
 rand_core.workspace = true
 rand_core_09 = { workspace = true, optional = true }
 rand_core_06 = { workspace = true, optional = true }
-getrandom_02 = { workspace = true, optional = true }
-getrandom_03 = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 chacha20 = { workspace = true, optional = true, features = ["rng"] }
 wyrand = { workspace = true, optional = true }

--- a/bevy_prng/README.md
+++ b/bevy_prng/README.md
@@ -24,6 +24,7 @@ By default, `bevy_prng` won't export anything _unless_ the feature/algorithm you
 - **`wyrand`** - This enables the exporting of the `WyRand` component from `wyrand`, the same algorithm in use within `fastrand`/`turborand`.
 - **`compat_06`** - This enables the old v0.6 `RngCore` trait implementation on the RNGs, providing additional compatibility with other crates that haven't yet upgraded to the latest `rand_core`/`rand` versions.
 - **`compat_09`** - This enables the old v0.9 `RngCore` trait implementation on the RNGs, providing additional compatibility with other crates that haven't yet upgraded to the latest `rand_core`/`rand` versions.
+- **`wasm_js`** - This enables the `getrandom` WASM JS backend, though this should only be activated conditionally for `wasm` targets. That requires extra steps outlined [here](#usage-within-web-wasm-environments).
 
 In addition to these feature flags to enable various supported algorithms, there's also **`serialize`** flag to provide `serde` support for `Serialize`/`Deserialize`.
 
@@ -46,6 +47,19 @@ All the below crates implement the necessary traits to be compatible with `bevy_
 - [wyrand](https://crates.io/crates/wyrand)
 - [rand_xoshiro](https://crates.io/crates/rand_xoshiro)
 - [rand_pcg](https://crates.io/crates/rand_pcg)
+
+## Usage within Web WASM environments
+
+To enable `bevy_prng` to work with Web WASM in `v0.14`, just paste the following into your `Cargo.toml` for your binary crate:
+
+```toml
+[target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
+bevy_prng = { version = "0.14", features = ["wasm_js"] }
+```
+
+This enables the `wasm_js` backend to be made available for `getrandom`, which will allow `bevy_prng` to compile correctly for web WASM environments. The reason for this is that `wasm32-unknown-unknown` is itself not actually a web target, so to actually target a web environment, we must specify the feature in order to activate `wasm-bindgen` to do its thing.
+
+If you have older versions of `getrandom` in your dep tree, enabling the `wasm_js` feature on `bevy_prng` should be enough to have these versions configured to work for Web WASM.
 
 ## Supported Versions & MSRV
 

--- a/bevy_prng/README.md
+++ b/bevy_prng/README.md
@@ -59,7 +59,16 @@ bevy_prng = { version = "0.14", features = ["wasm_js"] }
 
 This enables the `wasm_js` backend to be made available for `getrandom`, which will allow `bevy_prng` to compile correctly for web WASM environments. The reason for this is that `wasm32-unknown-unknown` is itself not actually a web target, so to actually target a web environment, we must specify the feature in order to activate `wasm-bindgen` to do its thing.
 
-If you have older versions of `getrandom` in your dep tree, enabling the `wasm_js` feature on `bevy_prng` should be enough to have these versions configured to work for Web WASM.
+If you have older versions of `getrandom` in your dep tree that are getting compiled in, then you might need to add further configuration to your `Cargo.toml` in order to enable Web WASM builds to compile correctly:
+
+```toml
+[target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
+bevy_prng = { version = "0.14", features = ["wasm_js"] }
+# Add the line below to make v0.3.4 getrandom work in Web WASM builds
+getrandom_03 = { version = "0.3.4", features = ["wasm_js"], package = "getrandom" }
+# Add the line below to make v0.2.17 getrandom work in Web WASM builds
+getrandom_02 = { version = "0.2.17", features = ["js"], package = "getrandom" }
+```
 
 ## Supported Versions & MSRV
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_prng"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bevy_ecs",
  "getrandom 0.4.1",
@@ -945,7 +945,7 @@ source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc90447
 
 [[package]]
 name = "bevy_rand"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bevy_app",
  "bevy_ecs",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -933,9 +933,6 @@ name = "bevy_prng"
 version = "0.14.1"
 dependencies = [
  "bevy_ecs",
- "bevy_reflect",
- "getrandom 0.2.17",
- "getrandom 0.3.4",
  "getrandom 0.4.1",
  "rand_core",
  "wyrand",
@@ -953,7 +950,6 @@ dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_prng",
- "bevy_reflect",
  "getrandom 0.4.1",
  "rand_core",
 ]
@@ -2116,29 +2112,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3991,12 +3972,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -20,18 +20,18 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0467c58e646d849edd7fe043d6711b8ad58f27a39a5f33886f1f2ca9852e8259"
+checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
 dependencies = [
  "uuid",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.33.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fce4cd9f6ea13c76d53403ff1583163f7a9e58381ecfbf4c8449affd7c09c24"
+checksum = "a191faf9cb278127e253ba80af4c588527b7b9d824c58220aca00bb162a5a460"
 dependencies = [
  "accesskit",
  "hashbrown 0.16.1",
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c001a603b958865ce466c92ac2487041ff402f994c705a3f12a5765e4e54a35e"
+checksum = "3dceb1d10a043047187e8fc6f4f11e02ab0ed3f8b5848c10cf19fc1e2191e0c2"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -53,23 +53,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3cdfe5e46c3f39d2d51bb6d6e5771347021889c5f6a7cade8ff7c401ccfbd7"
+checksum = "4983e64eb7e317c7d8f6348363d24f955bed51c0216ad67c19857c2b8605e576"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
  "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1da113a14288fc93435277734c73926de5d95f0d930ef3b9e894de29bae34"
+checksum = "e0e50a8f04c92b70e53ebfc6e64714de99e5deb0db092ea7de3b5aa8fceedcca"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -119,7 +119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cc",
  "cesu8",
  "jni",
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -322,7 +322,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "bevy"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_internal",
 ]
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "bevy_android"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "android-activity",
 ]
@@ -350,7 +350,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_animation_macros",
  "bevy_app",
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -413,7 +413,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -430,7 +430,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "blake3",
  "crossbeam-channel",
  "derive_more",
@@ -455,7 +455,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bevy_camera"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -526,16 +526,15 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
+ "indexmap",
  "nonmax",
- "radsort",
- "tracing",
 ]
 
 [[package]]
 name = "bevy_derive"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -545,7 +544,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "atomic-waker",
  "bevy_app",
@@ -561,7 +560,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -570,7 +569,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bumpalo",
  "concurrent-queue",
  "derive_more",
@@ -588,7 +587,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -599,7 +598,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -608,7 +607,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -627,7 +626,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -637,7 +636,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_render"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -648,6 +647,7 @@ dependencies = [
  "bevy_image",
  "bevy_math",
  "bevy_mesh",
+ "bevy_reflect",
  "bevy_render",
  "bevy_shader",
  "bevy_sprite_render",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -670,7 +670,7 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "futures-lite",
  "guillotiere",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_a11y",
  "bevy_android",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "bevy_light"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "bevy_material"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -835,7 +835,7 @@ dependencies = [
 [[package]]
 name = "bevy_material_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "approx",
  "arrayvec",
@@ -854,7 +854,7 @@ dependencies = [
  "glam",
  "itertools",
  "libm",
- "rand 0.9.2",
+ "rand",
  "rand_distr",
  "serde",
  "thiserror 2.0.18",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -874,7 +874,7 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_transform",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "derive_more",
  "hexasphere",
@@ -886,7 +886,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "critical-section",
  "foldhash 0.2.0",
@@ -907,7 +907,7 @@ dependencies = [
 [[package]]
 name = "bevy_post_process"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -933,15 +933,18 @@ name = "bevy_prng"
 version = "0.14.1"
 dependencies = [
  "bevy_ecs",
+ "bevy_reflect",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "getrandom 0.4.1",
- "rand_core 0.10.0",
+ "rand_core",
  "wyrand",
 ]
 
 [[package]]
 name = "bevy_ptr"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 
 [[package]]
 name = "bevy_rand"
@@ -950,8 +953,9 @@ dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_prng",
+ "bevy_reflect",
  "getrandom 0.4.1",
- "rand_core 0.10.0",
+ "rand_core",
 ]
 
 [[package]]
@@ -960,13 +964,13 @@ version = "0.14.0"
 dependencies = [
  "bevy",
  "bevy_rand",
- "rand 0.10.0",
+ "rand",
 ]
 
 [[package]]
 name = "bevy_reflect"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -994,7 +998,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -1007,7 +1011,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1033,15 +1037,15 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "derive_more",
  "downcast-rs 2.0.2",
  "encase",
- "fixedbitset",
  "glam",
  "image",
  "indexmap",
+ "itertools",
  "js-sys",
  "naga",
  "nonmax",
@@ -1059,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1070,7 +1074,7 @@ dependencies = [
 [[package]]
 name = "bevy_shader"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_asset",
  "bevy_platform",
@@ -1087,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1111,7 +1115,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite_render"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1132,7 +1136,7 @@ dependencies = [
  "bevy_text",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "derive_more",
  "fixedbitset",
@@ -1143,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1160,7 +1164,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1187,7 +1191,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1201,7 +1205,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1218,7 +1222,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1250,7 +1254,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui_render"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1274,13 +1278,14 @@ dependencies = [
  "bevy_utils",
  "bytemuck",
  "derive_more",
+ "indexmap",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_utils"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "async-channel",
  "bevy_platform",
@@ -1291,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1307,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy?branch=main#48ec375a3a3cdc904476ef1d13f9d71c9f2820d3"
+source = "git+https://github.com/bevyengine/bevy?branch=main#ea0d43eb67ab99d3ce157feffa7d2ea4bebcafd2"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -1356,9 +1361,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -1416,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -1464,7 +1469,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -1486,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1656,7 +1661,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1782,7 +1787,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.3",
@@ -2037,24 +2042,24 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -2071,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2082,21 +2087,20 @@ dependencies = [
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2107,7 +2111,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.3",
- "windows-link 0.2.1",
+ "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2117,9 +2134,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2129,23 +2148,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
- "rand_core 0.10.0",
+ "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "glam"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+checksum = "34627c5158214743a374170fed714833fdf4e4b0cbcc1ea98417866a4c5d4441"
 dependencies = [
  "bytemuck",
  "encase",
  "libm",
- "rand 0.9.2",
+ "rand",
  "serde_core",
 ]
 
@@ -2160,7 +2181,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -2169,7 +2190,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -2180,7 +2201,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2217,7 +2238,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "core_maths",
  "read-fonts",
@@ -2280,9 +2301,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hexasphere"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1276a77c583f9d6e20467188586366c5cdcb0bccbe6326c654b3f552db7d20"
+checksum = "177ea6330876de4ef08e184f827b98acc037614a4ce409902c5b0d53a9c2e951"
 dependencies = [
  "constgebra",
  "glam",
@@ -2341,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
 dependencies = [
  "rustversion",
 ]
@@ -2397,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2419,9 +2440,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libloading"
@@ -2430,7 +2451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2445,9 +2466,9 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.0",
+ "redox_syscall 0.7.1",
 ]
 
 [[package]]
@@ -2521,9 +2542,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -2534,7 +2555,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block",
  "core-graphics-types 0.2.0",
  "foreign-types",
@@ -2571,7 +2592,7 @@ checksum = "618f667225063219ddfc61251087db8a9aec3c3f0950c916b614e403486f1135"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -2613,7 +2634,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -2643,7 +2664,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2736,7 +2757,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -2752,7 +2773,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -2776,7 +2797,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation",
@@ -2818,7 +2839,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -2843,7 +2864,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation",
@@ -2855,7 +2876,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation",
@@ -2878,7 +2899,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -2910,7 +2931,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -2987,7 +3008,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3056,12 +3077,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,11 +3095,11 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3127,15 +3142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb458bb7f6e250e6eb79d5026badc10a3ebb8f9a15d1fff0f13d17c71f4d6dee"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -3219,40 +3225,12 @@ checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "rand_core 0.10.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -3263,12 +3241,12 @@ checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_distr"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand",
 ]
 
 [[package]]
@@ -3315,16 +3293,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3368,7 +3346,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "once_cell",
  "serde",
  "serde_derive",
@@ -3397,7 +3375,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3410,7 +3388,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -3570,7 +3548,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -3613,7 +3591,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3662,9 +3640,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3836,9 +3814,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.7+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -3947,9 +3925,9 @@ checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3971,11 +3949,11 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4015,6 +3993,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,9 +4018,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4047,9 +4031,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4061,9 +4045,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4071,9 +4055,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4084,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
 dependencies = [
  "unicode-ident",
 ]
@@ -4119,7 +4103,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4145,7 +4129,7 @@ version = "0.31.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "rustix 1.1.3",
  "wayland-backend",
  "wayland-scanner",
@@ -4157,7 +4141,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -4179,7 +4163,7 @@ version = "0.32.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -4191,7 +4175,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa98634619300a535a9a97f338aed9a5ff1e01a461943e8346ff4ae26007306b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4204,7 +4188,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9597cdf02cf0c34cd5823786dce6b5ae8598f05c2daf5621b6e178d4f7345f3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4235,9 +4219,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4260,7 +4244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cb534d5ffd109c7d1135f34cdae29e60eab94855a625dcfe1705f8bc7ad79f"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -4287,7 +4271,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -4337,7 +4321,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block",
  "bytemuck",
  "cfg-if",
@@ -4364,8 +4348,8 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "wgpu-types",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -4374,7 +4358,7 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e18308757e594ed2cd27dddbb16a139c42a683819d32a2e0b1b0167552f5840c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "js-sys",
  "log",
@@ -4393,36 +4377,14 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -4431,20 +4393,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4455,20 +4404,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4477,9 +4415,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4506,25 +4444,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -4532,17 +4454,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -4551,16 +4464,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4569,7 +4473,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4605,7 +4509,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4641,20 +4545,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4756,7 +4651,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "bytemuck",
  "calloop",
@@ -4866,7 +4761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -4904,11 +4799,11 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wyrand"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24a385d18bdb8db40f079c98c76839d9f694a65f03d42ee561e6d56a2b2bb6e"
+checksum = "b5484c3d24f0e2e117d30bce6f8792e193be33e2b6e0b3f8945ccf265c56c6da"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core",
 ]
 
 [[package]]
@@ -4955,7 +4850,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "dlib",
  "log",
  "once_cell",
@@ -5018,6 +4913,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,11 +23,9 @@ bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-fe
     "x11",
     "wayland",
     "2d_bevy_render",
-    "reflect_auto_register",
 ] }
 bevy_rand = { path = "..", version = "0.14", default-features = false, features = [
     "wyrand",
-    "bevy_reflect",
 ] }
 rand = { version = "0.10.0", default-features = false }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT OR Apache-2.0"
 version = "0.14.0"
 rust-version = "1.87.0"
 
+[features]
+wasm_js = ["bevy_rand/wasm_js"]
+
 [dependencies]
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
     "bevy_log",
@@ -20,9 +23,11 @@ bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-fe
     "x11",
     "wayland",
     "2d_bevy_render",
+    "reflect_auto_register",
 ] }
 bevy_rand = { path = "..", version = "0.14", default-features = false, features = [
     "wyrand",
+    "bevy_reflect",
 ] }
 rand = { version = "0.10.0", default-features = false }
 

--- a/examples/src/bin/mine_clicker.rs
+++ b/examples/src/bin/mine_clicker.rs
@@ -118,7 +118,7 @@ fn on_insert_mine_pos(
 
 // Clean up old mine data from our index before it is updated or if the mine is despawned
 fn on_replace_mine_pos(
-    trigger: On<Replace, MinePos>,
+    trigger: On<Discard, MinePos>,
     query: Query<&MinePos>,
     mut index: ResMut<SpatialIndex>,
 ) {


### PR DESCRIPTION
This PR is updated to move `getrandom` Web WASM enablement to `bevy_prng`. Docs updated instead to demonstrate what to do to get older `getrandom` versions to build in case they are still present in one's dep tree and being compiled in.