### PR TITLE
Add bevy_ecs/bevy_reflect to bevy_reflect feature

### DIFF
--- a/bevy_prng/Cargo.toml
+++ b/bevy_prng/Cargo.toml
@@ -15,7 +15,10 @@ rust-version = { workspace = true }
 default = []
 std = []
 thread_local_entropy = ["dep:chacha20", "std"]
-bevy_reflect = ["dep:bevy_reflect"]
+bevy_reflect = [
+    "dep:bevy_reflect",
+    "bevy_ecs/bevy_reflect",
+]
 serialize = [
     "dep:serde",
     "rand_pcg?/serde",


### PR DESCRIPTION
This should allow docs.rs to build bevy_prng in isolation, fixing the docs issue.